### PR TITLE
[Sticky navigation] fix #153 , replace titleElement.innerText by titl…

### DIFF
--- a/common/sticky-navigation/index.js
+++ b/common/sticky-navigation/index.js
@@ -69,7 +69,7 @@ let StickyNavigation = {
         let rawTitleList = document.querySelectorAll(this.props.titleSelector);
         return [].map.call(rawTitleList, (titleElement, titleIndex) => {
             return {
-                label: titleElement.innerText,
+                label: titleElement.innerHTML,
                 id: titleElement.getAttribute('id'),
                 offsetTop: titleIndex === 0 ? 0 : titleElement.offsetTop,
                 offsetHeight: titleElement.parentElement.offsetHeight


### PR DESCRIPTION
…eElement.innerHTML as the attribute does not exists on FF.