### PR TITLE
Hotfix 326 secondary actions

### DIFF
--- a/src/common/select-action/index.js
+++ b/src/common/select-action/index.js
@@ -20,7 +20,7 @@ const Dropdown = {
         return {
             position: 'right',
             iconProps: {
-                name: 'ellipsis-v'
+                name: 'more_vert'
             },
             shape: 'icon',
             operationList: []

--- a/src/list/action-contextual/index.js
+++ b/src/list/action-contextual/index.js
@@ -66,12 +66,13 @@ const actionContextualMixin = {
             let {primaryActionList: primaryActions, secondaryActionList: secondaryActions} = actionLists;
             if (1 === operation.priority) {
                 primaryActions.push(
-                    <buttonComponent
+                    <this.props.buttonComponent
                         handleOnClick={this._handleAction(key)}
                         key={key}
                         label={operation.label}
-                        shape={operation.style.shape || 'raised'}
-                        style={operation.style}
+                        shape={operation.style.shape || 'icon'}
+                        style={operation.style || {}}
+                        type='button'
                         {...this.props}
                         />
                 );
@@ -79,7 +80,7 @@ const actionContextualMixin = {
                 secondaryActions.push(operation);
             }
             return actionLists;
-        }, {primaryActionList: [], secondaryActionList: []});
+        }, {primaryActionList: [], secondaryActionList: []}, this);
         return (
             <div className='list-action-contextual'>
                 <span>{primaryActionList}</span>


### PR DESCRIPTION
- Fix default icon on dropdown to use `more_vert`
- The line primary actions are now `icon button` with type `button`

Fix #326 