### PR TITLE
Hotfix text for

### DIFF
--- a/src/common/field/mixin/built-in-components.js
+++ b/src/common/field/mixin/built-in-components.js
@@ -117,8 +117,8 @@ const fieldBuiltInComponentsMixin = {
     * @return {object} - The display part of the compoennt if the mode is not edit.
     */
     display() {
-        const {values, value} = this.state;
-        const {name, valueKey, labelKey} = this.props;
+        const {value} = this.state;
+        const {name, valueKey, labelKey, values} = this.props;
         const _processValue = values ? result(find(values, {[valueKey || 'code']: value}), labelKey || 'label') : value;
         const buildedDislplayProps = assign({}, this.props, {
             id: name,

--- a/src/common/mixin/built-in-components.js
+++ b/src/common/mixin/built-in-components.js
@@ -4,6 +4,7 @@ const React = require('react');
 const changeMode = require('focus').application.changeMode;
 const assign = require('object-assign');
 const result = require('lodash/object/result');
+const find = require('lodash/collection/find');
 // Components
 
 const Field = require('../field').component;

--- a/src/common/mixin/built-in-components.js
+++ b/src/common/mixin/built-in-components.js
@@ -3,7 +3,7 @@
 const React = require('react');
 const changeMode = require('focus').application.changeMode;
 const assign = require('object-assign');
-
+const result = require('lodash/object/result');
 // Components
 
 const Field = require('../field').component;
@@ -12,6 +12,7 @@ const Button = require('../button/action').component;
 const MemoryList = require('../list').component;
 const Table = require('../../list/table').list.component;
 const List = require('../../list/selection').list.component;
+
 
 // Mixins
 
@@ -72,13 +73,16 @@ module.exports = {
     textFor(name, options){
         options = options || {};
         const def = (this.definition && this.definition[name]) ? this.definition[name] : {};
+        const fieldProps = this._buildFieldProps(name, options, this);
+        const value = this.state[name];
+        const {valueKey, labelKey, values} = fieldProps;
+        const _processValue = values ? result(find(values, {[valueKey || 'code']: value}), labelKey || 'label') : value;
         return (
             <Text
-                FieldComponent={def.FieldComponent}
                 formatter={options.formatter || def.formatter}
                 name={options.name || `${this.definitionPath}.${name}`}
                 style={options.style}
-                value={this.state[name]}
+                value={_processValue}
                 />
         );
     },


### PR DESCRIPTION
`textFor(property, {listName: 'myList'})` can now be used the same way as the display component. 
Fix #243 