### PR TITLE
[action-button] add translation in contextual help label (on mouse hover the button)

### DIFF
--- a/src/common/button/action/example/index.js
+++ b/src/common/button/action/example/index.js
@@ -1,5 +1,19 @@
 const Button = FocusComponents.common.button.action.component;
 
+/***********************************************************************************************************************/
+/* to test internationalisation. */
+var resources = {
+    dev: {
+        translation: {
+            'button': {
+                'label': 'Button avec tradution'
+            }
+        }
+    }
+};
+i18n.init({resStore: resources});
+/***********************************************************************************************************************/
+
 const ButtonSample = React.createClass({
     /**
     * Render the component.
@@ -8,17 +22,19 @@ const ButtonSample = React.createClass({
     render() {
         return (
             <div className='button-example'>
-                <Button label='Bouton primaire' type='button' handleOnClick={()=> alert('click bouton')}/>
-                <br /><br />
-                <Button icon='alarm' color='colored' label='Bouton primaire' shape='fab' type='button' handleOnClick={()=> alert('click bouton')}/>
-                <br /><br />
-                <Button icon='build' label='Bouton icone' type='button' handleOnClick={()=> alert('click bouton')}/>
-                <br /><br />
-                <Button icon='build' color='accent' label='Bouton accent' type='button' handleOnClick={()=> alert('click bouton')}/>
-                <br /><br />
-                <Button icon='mood' color='colored' label='iconbutton' shape='icon' type='button' handleOnClick={()=> alert('click bouton')}/>
-                <br /><br />
-                <Button icon='mood' label='minifabbutton' color='announcement' shape='mini-fab' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <Button label='Bouton primaire' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <br /><br />
+            <Button icon='alarm' color='colored' label='Bouton primaire' shape='fab' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <br /><br />
+            <Button icon='build' label='Bouton icone' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <br /><br />
+            <Button icon='build' color='accent' label='Bouton accent' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <br /><br />
+            <Button icon='mood' color='colored' label='iconbutton' shape='icon' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <br /><br />
+            <Button icon='mood' label='minifabbutton' color='announcement' shape='mini-fab' type='button' handleOnClick={()=> alert('click bouton')}/>
+            <br /><br />
+            <Button label='button.label' type='button' handleOnClick={()=> alert('click bouton')}/>
             </div>
         );
     }

--- a/src/common/button/action/index.js
+++ b/src/common/button/action/index.js
@@ -103,7 +103,7 @@ const buttonMixin = {
     render() {
         const {id, type, label, style} = this.props;
         return (
-            <button alt={label} className={this._className()} data-focus="button-action" id={id} onClick={this.handleOnClick} style={style} title={label} type={type}>
+            <button alt={this.i18n(label)} className={this._className()} data-focus="button-action" id={id} onClick={this.handleOnClick} style={style} title={this.i18n(label)} type={type}>
                 {this._renderIcon()}
                 {this._renderLabel()}
             </button>


### PR DESCRIPTION
On action-button, the conxtual help label (alt + title property) is now transleted.

![image](https://cloud.githubusercontent.com/assets/5349745/9898057/6ce55020-5c4f-11e5-94ce-742381acb14f.png)

fix #296 
