### PR TITLE
Feature refactor input toggle

### DIFF
--- a/showcase/index.html
+++ b/showcase/index.html
@@ -17,6 +17,17 @@
     loadAssets().then((d)=>{
         const Showcase = FocusComponents.showcase.layout;
         const Catalog = FocusComponents.showcase.catalog;
+        const i18nConfig = {
+            resStore: {
+                'en-GB': {
+                    translation: {}
+                }
+            },
+            lng: 'en-GB'
+        };
+        i18n.init(i18nConfig, () => {
+            console.log('Translation correctly initialized.');
+        });
         ReactDOM.render(<Showcase title='Component catalog'><Catalog /></Showcase>, document.querySelector("body"));
     });
     </script>

--- a/src/input/checkbox/package.json
+++ b/src/input/checkbox/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha __tests__/index.js"
   },
   "keywords": [
     "dumb",

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -1,7 +1,9 @@
 import text from './text';
 import checkbox from './checkbox';
+import toggle from './toggle';
 
 export default {
     Checkbox: checkbox,
-    Text: text
+    Text: text,
+    Toggle: toggle
 };

--- a/src/input/toggle/__tests__/.eslintrc
+++ b/src/input/toggle/__tests__/.eslintrc
@@ -1,0 +1,3 @@
+{
+    "extends": "../../../../spec/__tests__/.eslintrc"
+}

--- a/src/input/toggle/__tests__/index.js
+++ b/src/input/toggle/__tests__/index.js
@@ -1,0 +1,38 @@
+import InputToggle from '../';
+
+global.componentHandler = {
+    upgradeElement: sinon.stub(),
+    downgradeElements: sinon.stub()
+};
+
+describe.only('The input toggle', () => {
+    describe('when mounted', () => {
+        let renderedTest;
+        const onChangeSpy = sinon.spy();
+        before(() => {
+            renderedTest = TestUtils.renderIntoDocument(<InputToggle onChange={onChangeSpy} value={true} />);
+        });
+
+        it('should hold the provided initial value', () => {
+            expect(renderedTest.getValue()).to.equal(true);
+        });
+    });
+    describe('when clicked', () => {
+        let renderedTest;
+        let toggle;
+        const onChangeSpy = sinon.spy();
+        before(() => {
+            renderedTest = TestUtils.renderIntoDocument(<InputToggle onChange={onChangeSpy} value={false} />);
+            toggle = ReactDOM.findDOMNode(renderedTest.refs.toggle);
+            TestUtils.Simulate.change(toggle, {target: {checked: true}});
+        });
+
+        it('should call the handeOnChange prop', () => {
+            expect(onChangeSpy).to.be.called.once;
+        });
+
+        it('should not change the toggle value if the parent does not explicitly change it', () => {
+            expect(renderedTest.getValue()).to.equal(false);
+        });
+    });
+});

--- a/src/input/toggle/example/index.js
+++ b/src/input/toggle/example/index.js
@@ -4,7 +4,7 @@ const {Component} = React;
 
 // Components
 
-const Toggle = FocusComponents.input.toggle;
+const Toggle = FocusComponents.input.Toggle;
 
 class InputToggleSample extends Component {
     /**

--- a/src/input/toggle/example/index.js
+++ b/src/input/toggle/example/index.js
@@ -1,0 +1,45 @@
+// Dependencies
+
+const {Component} = React;
+
+// Components
+
+const Toggle = FocusComponents.input.toggle;
+
+class InputToggleSample extends Component {
+    /**
+    * Handle click action to get check value.
+    */
+    handleGetValueClick = () => {
+        const value = this.refs.toggleTestGetValue.getValue();
+        alert('Toggle value: ' + value);
+    }
+
+    /**
+    * Render the component.
+    * @return {object} React node
+    */
+    render() {
+        return (
+            <div>
+                <h3>Input toggle</h3>
+                <Toggle label='My awsome toggle' value={true}/>
+
+                <h3>Unselected toggle</h3>
+                <Toggle label='My awsome toggle' value={false} />
+
+                <h3>Without label</h3>
+                <Toggle value={true} />
+
+                <h3>Get Toggle value</h3>
+                <div style={{float: 'left', width: '300px'}}>
+                    <Toggle label='My awsome toggle' ref='toggleTestGetValue' value={true}/>
+                </div>
+                <div style={{marginLeft: '300px'}}>
+                    <button onClick={this.handleGetValueClick}>Get the toggle value</button>
+                </div>
+        </div>);
+    }
+}
+
+return <InputToggleSample />;

--- a/src/input/toggle/index.js
+++ b/src/input/toggle/index.js
@@ -1,0 +1,46 @@
+import React, {Component, PropTypes} from 'react';
+import ReactDOM from 'react-dom';
+import Translation from '../../behaviours/translation';
+import Material from '../../behaviours/material';
+
+const propTypes = {
+    label: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.bool.isRequired
+};
+
+const defaultProps = {
+    value: false
+};
+
+const displayName = 'InputToggle';
+
+@Translation
+@Material('mdlHolder')
+class InputToggle extends Component {
+    getValue = () => {
+        const domElement = ReactDOM.findDOMNode(this.refs.toggle);
+        return domElement.checked;
+    }
+
+    handleOnChange = ({target: {checked}}) => {
+        const {onChange} = this.props;
+        onChange(checked);
+    }
+
+    render() {
+        const {label, value} = this.props;
+        return (
+            <label className='mdl-switch mdl-js-switch mdl-js-ripple-effect' data-focus='input-toggle' ref='mdlHolder'>
+                <input checked={value} className='mdl-switch__input' onChange={this.handleOnChange} ref='toggle' type='checkbox' />
+                {label && <span className='mdl-switch__label'>{this.i18n(label)}</span>}
+            </label>
+        );
+    }
+}
+
+InputToggle.propTypes = propTypes;
+InputToggle.defaultProps = defaultProps;
+InputToggle.displayName = displayName;
+
+export default InputToggle;

--- a/src/input/toggle/package.json
+++ b/src/input/toggle/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "Input toggle",
+  "version": "1.0.0",
+  "description": "Input toggle component.",
+  "main": "index.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "mocha __tests__/index.js"
+  },
+  "keywords": [
+    "dumb",
+    "input",
+    "boolean",
+    "toggle",
+    "material"
+  ],
+  "author": "focus@kleegroup.com",
+  "license": "MIT"
+}


### PR DESCRIPTION
# Input toggle

## Description
The component no longer holds a state, it is now assumed that the value is managed by the parent through the `value` and `onChange` props.

## Screenshot
![image](https://cloud.githubusercontent.com/assets/4435377/9938232/ac127cb2-5d64-11e5-98ac-2719c14e9540.png)

## Example

See [here](https://github.com/KleeGroup/focus-components/blob/7259d6e1c3d8e8a0168d096a9800186545c2ef1f/src/input/toggle/example/index.js)