### PR TITLE
Fix action bar Material sort icon.

### DIFF
--- a/src/list/action-bar/index.js
+++ b/src/list/action-bar/index.js
@@ -94,7 +94,7 @@ const ActionBar = {
                     style: this._getSelectedStyle(description.key + description.order, orderSelectedParsedKey)
                 });
             }
-            const orderIcon = this.props.orderSelected.order ? 'sort-alpha-desc' : 'sort-alpha-asc';
+            const orderIcon = 'sort_by_alpha';
             const {style} = this.props;
             return (
                 <div style={style.actions.sort}>


### PR DESCRIPTION

Note : in Font-awesome there were a http://fortawesome.github.io/Font-Awesome/icon/sort-alpha-desc/ and a http://fortawesome.github.io/Font-Awesome/icon/sort-alpha-asc/

In material, there is only a https://www.google.com/design/icons/#ic_sort_by_alpha

![giphy 3](https://cloud.githubusercontent.com/assets/9380855/10022538/b32afff0-614d-11e5-9a4c-08b97293dae8.gif)
