### PR TITLE
[input-text + input-textarea] correction of overprint on fieldfor.

### DIFF
--- a/src/common/input/text/index.js
+++ b/src/common/input/text/index.js
@@ -103,7 +103,7 @@ const inputTextComponent = {
         return (
             <div className='mdl-textfield mdl-js-textfield' data-focus='input-text' style={style}>
                 <input className='mdl-textfield__input' ref='inputText' {...inputProps} pattern={pattern} />
-                <label className='mdl-textfield__label' htmlFor={name}>{this.i18n(placeHolder)}</label>
+                <label className='mdl-textfield__label' htmlFor={name}>{value ? '' : this.i18n(placeHolder)}</label>
                 {error &&
                     <span className="mdl-textfield__error">{error}</span>
                 }

--- a/src/common/input/textarea/index.js
+++ b/src/common/input/textarea/index.js
@@ -64,10 +64,11 @@ const textAreaMixin = {
     */
     render: function renderTextArea() {
         const {cols, label, maxlength, minlength, rows} = this.props;
+        const {value} = this.state;
         return (
             <div className="mdl-textfield mdl-js-textfield" data-focus="input-textarea">
-                <textarea className="mdl-textfield__input" cols={cols} maxLength={maxlength} minLength={minlength} onChange={this._onChange} ref='textarea' rows={rows} type="text">{this.state.value}</textarea>
-                <label className="mdl-textfield__label">{this.i18n(label)}</label>
+                <textarea className="mdl-textfield__input" cols={cols} maxLength={maxlength} minLength={minlength} onChange={this._onChange} ref='textarea' rows={rows} type="text">{value}</textarea>
+                <label className="mdl-textfield__label">{value ? '' : this.i18n(label)}</label>
             </div>
         );
     }


### PR DESCRIPTION
When a form is displayed by default in edit mode, the fields with placeholder are now display with overprint of the placeholder.

![image](https://cloud.githubusercontent.com/assets/5349745/10103307/6a6c0ff4-63a3-11e5-8c7e-f36b9bf021fc.png)

fix #321 