### PR TITLE
[field + input-text] display error when required. fix #396

### DIFF
--- a/src/common/field/index.js
+++ b/src/common/field/index.js
@@ -53,11 +53,12 @@ const FieldMixin = {
     },
     /** @inheritdoc */
     render() {
+        const {error} = this.state;
         const {FieldComponent, InputLabelComponent, domain, codeResolver, searcher, isRequired, values, hasLabel, isEdit} = this.props;
         const isCustomComponent = FieldComponent || InputLabelComponent;
         const {autocomplete, label, input, select, display} = this;
         return (
-            <div className={this._className()} data-domain={domain} data-focus='field' data-mode={isEdit ? 'edit' : 'consult'} data-required={isRequired}>
+            <div className='mdl-grid' data-domain={domain} data-focus='field' data-mode={isEdit ? 'edit' : 'consult'} data-required={isRequired} data-valid={!error}>
                 {isCustomComponent && this._renderFieldComponent()}
                 {!isCustomComponent && hasLabel && label()}
                 {!isCustomComponent &&

--- a/src/common/field/style/field.scss
+++ b/src/common/field/style/field.scss
@@ -3,6 +3,7 @@ $field-input-width-normal: 250px;
 $field-input-width-short: 150px;
 $field-input-width-date: 100px;
 $field-label-font-size:13px; //TODO TGN à revoir.
+$field-label-error-color:rgb(222, 50, 38);
 
 [data-focus="field"] {
     padding: 0;
@@ -15,6 +16,14 @@ $field-label-font-size:13px; //TODO TGN à revoir.
         }
     }
     &[data-mode="edit"] {
+        &[data-valid="false"] {
+            [data-focus="field-label-container"] {
+                label {
+                    color:$field-label-error-color;
+                }
+            }
+        }
+
         [data-focus="field-label-container"] {
             label {
                 margin:4px 0;

--- a/src/common/input/text/index.js
+++ b/src/common/input/text/index.js
@@ -100,8 +100,9 @@ const inputTextComponent = {
         const {error, name, placeHolder, style} = this.props;
         const inputProps = assign({}, this.props, {value}, {id: name, onChange: this._handleInputChange, onKeyPress: this._handleInputKeyPress});
         const pattern = error ? 'hasError' : null; //add pattern to overide mdl error style when displaying an focus error.
+        const cssClass = `mdl-textfield mdl-js-textfield ${error ? 'is-invalid' : ''}`;
         return (
-            <div className='mdl-textfield mdl-js-textfield' data-focus='input-text' style={style}>
+            <div className={cssClass} data-focus='input-text' style={style}>
                 <input className='mdl-textfield__input' ref='inputText' {...inputProps} pattern={pattern} />
                 <label className='mdl-textfield__label' htmlFor={name}>{this.i18n(placeHolder)}</label>
                 {error &&


### PR DESCRIPTION
Now display the error when the field is required.

Display also the label in red.

![image](https://cloud.githubusercontent.com/assets/5349745/10106389/a7f6a314-63b4-11e5-9355-a27b0ce400ca.png)


 fix #396