### PR TITLE
Fix label override

### DIFF
--- a/src/common/field/mixin/built-in-components.js
+++ b/src/common/field/mixin/built-in-components.js
@@ -80,10 +80,10 @@ const fieldBuiltInComponentsMixin = {
     * @returns {Component} - The builded label component.
     */
     label() {
-        const {name} = this.props;
+        const {name, label} = this.props;
         return (
             <div className ={`${this._getLabelGridClassName()}`} data-focus='field-label-container'>
-                <Label name={name} />
+                <Label name={name} text={label} />
             </div>
         );
     },

--- a/src/common/label/index.js
+++ b/src/common/label/index.js
@@ -3,6 +3,7 @@
 const {builder, types} = require('focus-core').component;
 const i18nBehaviour = require('../i18n/mixin');
 const styleBehaviour = require('../../mixin/stylable');
+
 /**
 * Label mixin for form.
 * @type {Object}
@@ -11,14 +12,16 @@ const labelMixin = {
     mixins: [i18nBehaviour, styleBehaviour],
     /** @inheritdoc */
     propTypes: {
-        name: types('string').isRequired
+        name: types('string').isRequired,
+        text: types('string')
     },
     /** @inheritdoc */
     render() {
-        const {name, style} = this.props;
+        const {name, text, style} = this.props;
+        const content = text || name;
         return (
             <label className={style.className} htmlFor={name}>
-                {this.i18n(name)}
+                {this.i18n(content)}
             </label>
         );
     }


### PR DESCRIPTION
Fix #430 Now the label props overrides the name props on fields. Add a text props on Label tag to have a different content.
```jsx
this.fieldFor('propertyName', {label: 'myAwesomeLabel')
<Label name='propertyName' text='content' />
```

Maybe this will evolve in the furure version to a `<Label name='propertyN
ame'>LabelContent<Label>`