### PR TITLE
[input] Improvement on formatter and disabled.

### DIFF
--- a/src/components/input/text/__tests__/input-text-test.js
+++ b/src/components/input/text/__tests__/input-text-test.js
@@ -67,17 +67,18 @@ describe('The input text', () => {
         });
     });
     describe('when a formatter is provided', () => {
-        let component, htmlInput, onChange;
+        let component, htmlInput, onChange, isEditFormatterSpy;
         const testValue = 'MY_TEST_VALUE';
         const formatedValue = 'MY_FORMATED_VALUE';
         before(
             () => {
                 onChange = identity;
+                isEditFormatterSpy = sinon.spy();
                 /**
                  * The formatter test.
                  * @return {string} - The formated value
                  */
-                function formatter(){return formatedValue; }
+                function formatter(value, mode){ isEditFormatterSpy(mode); return formatedValue; } // eslint-disable-line
                 component = renderIntoDocument(<Input formatter={formatter} name='inputName' onChange={onChange} value={testValue}/>);
                 htmlInput = ReactDOM.findDOMNode(component.refs.htmlInput);
 
@@ -86,24 +87,34 @@ describe('The input text', () => {
         it('should format the value in the DOM', () => {
             expect(htmlInput.value).to.equal(formatedValue);
         });
+        it('should call the isEdit formatter with the mode', () => {
+            expect(isEditFormatterSpy).to.have.been.calledOnce;
+            expect(isEditFormatterSpy).to.have.been.calledWith({isEdit: true});
+        });
     });
     describe('when an unformatter is provided', () => {
-        let component, onChange;
+        let component, onChange, unFormatterSpy, componentValue;
         const testValue = 'MY_TEST_VALUE';
         const unformatedValue = 'MY_UN_FORMATED_VALUE';
         before(
             () => {
+                unFormatterSpy = sinon.spy();
                 onChange = identity;
                 /**
                  * The unformatter test.
                  * @return {string} - The formated value
                  */
-                function unformatter(){return unformatedValue; }
+                function unformatter(value, mode){ unFormatterSpy(mode);  return unformatedValue; }//eslint-disable-line
                 component = renderIntoDocument(<Input name='inputName' onChange={onChange} unformatter={unformatter} value={testValue}/>);
+                componentValue = component.getValue();
             }
         );
         it('should unformat the getValue', () => {
-            expect(component.getValue()).to.equal(unformatedValue);
+            expect(componentValue).to.equal(unformatedValue);
+        });
+        it('should call unformatter with mode', ()=>{
+            expect(unFormatterSpy).to.have.been.calledOnce;
+            expect(unFormatterSpy).to.have.been.calledWith({isEdit: true});
         });
     });
     describe('when an error is provided', () => {

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -6,6 +6,7 @@ import ComponentBaseBehaviour from '../../../behaviours/component-base';
 import MDBehaviour from '../../../behaviours/material';
 const MODE = {isEdit: true};
 const propTypes = {
+    disabled: PropTypes.bool,
     error: PropTypes.string,
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -21,9 +22,10 @@ const propTypes = {
 };
 
 const defaultProps = {
-    type: 'text',
+    disabled: false,
     formatter: identity,
-    unformatter: identity
+    unformatter: identity,
+    type: 'text'
 };
 
 /**

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import {identity} from 'lodash/utility';
 import ComponentBaseBehaviour from '../../../behaviours/component-base';
 import MDBehaviour from '../../../behaviours/material';
-
+const MODE = {isEdit: true};
 const propTypes = {
     error: PropTypes.string,
     name: PropTypes.string.isRequired,
@@ -40,7 +40,7 @@ class InputText extends Component {
     getValue = () => {
         const {unformatter} = this.props;
         const domEl = ReactDOM.findDOMNode(this.refs.htmlInput);
-        return unformatter(domEl.value);
+        return unformatter(domEl.value, MODE);
     }
     /**
      * Handle the change on the input text, it only propagate the value.
@@ -50,7 +50,7 @@ class InputText extends Component {
     _handleInputChange = (evt) =>{
         const {unformatter, onChange} = this.props;
         const {value} = evt.target;
-        return onChange(unformatter(value));
+        return onChange(unformatter(value, MODE));
     }
     /**
      * @inheritdoc
@@ -58,7 +58,7 @@ class InputText extends Component {
     */
     render() {
         const {error, name, placeholder, style, value: rawValue, formatter, ...otherProps} = this.props;
-        const value = formatter(rawValue);
+        const value = formatter(rawValue, MODE);
         const pattern = error ? 'hasError' : null; //add pattern to overide mdl error style when displaying an focus error.
         const inputProps = {...otherProps, value, id: name, onChange: this._handleInputChange, pattern};
         return (


### PR DESCRIPTION
Input
- Formatter and unformatter now have the following signature `function(value, options){  /**options = {isEdit: true/false}; and // your code*/ return value;}`, add working test for these cases.
- The disabled property is now validate
It should fix #414