### PR TITLE
Field For - display text : remove translation on get Value

### DIFF
--- a/src/common/display/text/index.js
+++ b/src/common/display/text/index.js
@@ -29,8 +29,7 @@ const displayTextMixin = {
     */
     renderValue(){
         const {formatter, value} = this.props;
-        const translatedValue = value ? this.i18n(value) : value;
-        return formatter(translatedValue);
+        return formatter(value);
     },
     /** @inheritdoc */
     render: function renderInput() {

--- a/src/common/form/example/index.js
+++ b/src/common/form/example/index.js
@@ -73,7 +73,8 @@ var domain = {
     'DO_OUI_NON': {
         SelectComponent: FocusComponents.common.select.radio.component,
         refContainer: {yesNoList: [{code: true, label: "select.yes"}, {code: false, label: "select.no"}]},
-        listName: 'yesNoList'
+        listName: 'yesNoList',
+        formatter: i18n.t(value)
     }
 };
 Focus.definition.domain.container.setAll(domain);


### PR DESCRIPTION
# Display text

### Corrections

Remove translation on getValue.

it will have impacts on boolean radio select which would not be translated anymore. Please add a formatter on you domain this way : 
```javascrit
    'DO_OUI_NON': {
        SelectComponent: FocusComponents.common.select.radio.component,
        refContainer: {yesNoList: [{code: true, label: "select.yes"}, {code: false, label: "select.no"}]},
        listName: 'yesNoList',
        formatter: i18n.t(value)
    }
```

### Fixes

Fix #367 