### PR TITLE
[Layout] correction of props warnings

### DIFF
--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -19,12 +19,12 @@ const defaultProps = {
 
 // component props definition.
 const propTypes = {
-    AppHeader: PropTypes.element,
-    ErrorCenter: PropTypes.element,
+    AppHeader: PropTypes.oneOfType([PropTypes.func,PropTypes.element]),
+    ErrorCenter: PropTypes.oneOfType([PropTypes.func,PropTypes.element]),
     Footer: PropTypes.string,
-    LoadingBar: PropTypes.element,
-    MenuLeft: PropTypes.element,
-    MessageCenter: PropTypes.element
+    LoadingBar: PropTypes.oneOfType([PropTypes.func,PropTypes.element]),
+    MenuLeft: PropTypes.oneOfType([PropTypes.func,PropTypes.element]),
+    MessageCenter: PropTypes.oneOfType([PropTypes.func,PropTypes.element])
 };
 
 /**


### PR DESCRIPTION
# Layout

## Console warning

### Description
The use of a Layout component showed console warnings on the declaration of Element type props.

### Patch
Description of Layout component props have been precised. Now console warning are no longer displayed.