### PR TITLE
Fix #551 datapicker on change

### DIFF
--- a/src/components/input/date/__tests__/index.js
+++ b/src/components/input/date/__tests__/index.js
@@ -170,4 +170,48 @@ describe('The input date', () => {
             expect(ReactDOM.findDOMNode(renderedTest.refs.date.refs.input.refs.htmlInput).value).to.equal(invalidDateString);
         });
     });
+    describe('when blurred with a valid date', () => {
+        const validDate = (moment('10/10/2015')).toISOString();
+        const onChangeSpy = sinon.spy();
+        class TestComponent extends Component {
+            render = () => {
+                return <InputDate onChange={onChangeSpy} ref='date' value={validDate} />;
+            }
+        }
+        let renderedTest;
+        before(() => {
+            renderedTest = TestUtils.renderIntoDocument(<TestComponent />);
+            const input = ReactDOM.findDOMNode(renderedTest.refs.date.refs.input.refs.htmlInput);
+            TestUtils.Simulate.blur(input);
+        });
+        it('should call the onChange prop with the corresponding ISOString', () => {
+            expect(onChangeSpy).to.have.been.calledWith(validDate);
+        });
+    });
+    describe('when a date is chosen in the date picker', () => {
+        const validDate = (moment('10/10/2015')).toISOString();
+        const onChangeSpy = sinon.spy();
+        let renderedTest;
+        before(done => {
+            const onChange = cb => {
+                return data => {
+                    onChangeSpy(data);
+                    cb();
+                }
+            };
+            class TestComponent extends Component {
+                render = () => {
+                    return <InputDate onChange={onChange(done)} ref='date' value={validDate} />;
+                }
+            }
+            renderedTest = TestUtils.renderIntoDocument(<TestComponent />);
+            const input = ReactDOM.findDOMNode(renderedTest.refs.date.refs.input.refs.htmlInput);
+            TestUtils.Simulate.focus(input);
+            const firstDay = ReactDOM.findDOMNode(TestUtils.scryRenderedDOMComponentsWithClass(renderedTest, 'dp-day')[0]);
+            TestUtils.Simulate.click(firstDay);
+        });
+        it('should call the onChange prop with the corresponding ISOString', () => {
+            expect(onChangeSpy).to.have.been.calledWith((moment('09/27/2015')).toISOString());
+        });
+    });
 });

--- a/src/components/input/date/index.js
+++ b/src/components/input/date/index.js
@@ -117,6 +117,7 @@ class InputDate extends Component {
     _onDropDownChange = (text, date) => {
         if (date._isValid) {
             this.setState({displayPicker: false}, () => {
+                this.props.onChange(date.toISOString());
                 this._onInputChange(this._formatDate(date.toISOString())); // Add 12 hours to avoid skipping a day due to different locales
             });
         }

--- a/test/mocha-bootload.js
+++ b/test/mocha-bootload.js
@@ -9,8 +9,15 @@ const sinonChai = require('sinon-chai');
 const chaiSubset = require('chai-subset');
 chai.use(chaiSubset);
 chai.use(sinonChai);
-const React = require('react');
 
+// Js dom
+import jsdom from 'jsdom';
+global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
+global.window = document.defaultView;
+global.navigator = {
+    userAgent: 'node.js'
+};
+const React = require('react');
 // Globals
 global.React = require('react');
 global.ReactDOM = require('react-dom');
@@ -19,10 +26,7 @@ global.sinon = sinon;
 global.TestUtils = require('react-addons-test-utils');
 global.sandbox = require('./sandbox');
 global.componentHandler = {upgradeElement: function(){}};
-// Js dom
-import jsdom from 'jsdom';
-global.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
-global.window = document.defaultView;
+
 // take all properties of the window object and also attach it to the
 // from mocha-jsdom https://github.com/rstacruz/mocha-jsdom/blob/master/index.js#L80
 function propagateToGlobal (window) {


### PR DESCRIPTION
# [Input date] Fixes #551 

## Call onChange prop when date is chosen from date picker

`onChange` prop was not called when the users chose a date from the picker. It was only called when the input field was blurred.

## Patch

Add a call to the prop in case the date is chosen from the picker