### PR TITLE
Fix #573 advanced search is selection

### DIFF
--- a/src/list/action-bar/index.js
+++ b/src/list/action-bar/index.js
@@ -28,6 +28,7 @@ const ActionBar = {
     */
     getDefaultProps() {
         return {
+            isSelection: true,
             selectionStatus: 'none', // none, selected, partial
             selectionAction(selectionStatus) {
                 console.warn(selectionStatus);
@@ -71,11 +72,11 @@ const ActionBar = {
             }
         ];
         const {style} = this.props;
-        return (
+        return this.props.isSelection ? (
             <div style={style.actions.select}>
                 <Dropdown iconProps={this._getSelectionObjectIcon()} operationList={selectionOperationList}/>
             </div>
-        );
+        ) : null;
     },
 
     /**

--- a/src/page/search/advanced-search/action-bar.js
+++ b/src/page/search/advanced-search/action-bar.js
@@ -87,6 +87,7 @@ const Bar = {
                 groupLabelPrefix='live.filter.facets.'
                 groupSelectedKey={this.props.groupingKey}
                 groupableColumnList={this.props.groupableColumnList}
+                isSelection={this.props.isSelection}
                 operationList={this.props.operationList}
                 orderAction={this._orderAction}
                 orderSelected={this.props.sortBy}

--- a/src/page/search/advanced-search/index.js
+++ b/src/page/search/advanced-search/index.js
@@ -196,7 +196,7 @@ const AdvancedSearch = {
     */
     _renderActionBar() {
         const {facets, groupingKey, selectedFacets, selectionStatus, sortBy} = this.state;
-        const {lineOperationList, orderableColumnList} = this.props;
+        const {isSelection, lineOperationList, orderableColumnList} = this.props;
         const groupableColumnList = facets ? Object.keys(facets).reduce((result, facetKey) => {
             result[facetKey] = facetKey;
             return result;
@@ -209,6 +209,7 @@ const AdvancedSearch = {
                 action={this._action}
                 groupSelectedKey={groupingKey}
                 groupableColumnList={groupableColumnList}
+                isSelection={isSelection}
                 operationList={lineOperationList}
                 orderSelected={sortBy}
                 orderableColumnList={orderableColumnList}


### PR DESCRIPTION
# [Advanced search] Fixes #573 

## Remove selection icon when `isSelection` is set to `false`

The selection icon is still present even if the `isSelection` is set to `false`.

## Patch

Do not display any selection dropdown in that case.