### PR TITLE
Fix #562 button mini fab

### DIFF
--- a/src/common/button/action/index.js
+++ b/src/common/button/action/index.js
@@ -36,7 +36,7 @@ const buttonMixin = {
         label: types('string'),
         handleOnClick: types('function'),
         type: oneOf(['submit', 'button']),
-        shape: oneOf([undefined, 'raised', 'fab', 'mini', 'icon', 'mini-fab']),
+        shape: oneOf([undefined, 'raised', 'fab', 'icon', 'mini-fab']),
         color: oneOf([undefined, 'colored', 'primary', 'accent']),
         hasRipple: types('bool'),
         isJs: types('bool'),
@@ -59,7 +59,24 @@ const buttonMixin = {
     */
     _className() {
         const {shape, color, hasRipple, isJs} = this.props;
-        const SHAPE_CLASS = shape ? `${BUTTON_PRFX}${shape}` : '';
+        let SHAPE_CLASS;
+        switch (shape) {
+            case 'raised':
+                SHAPE_CLASS = `${BUTTON_PRFX}raised`;
+                break;
+            case 'fab':
+                SHAPE_CLASS = `${BUTTON_PRFX}fab`;
+                break;
+            case 'icon':
+                SHAPE_CLASS = `${BUTTON_PRFX}icon`;
+                break;
+            case 'mini-fab':
+                SHAPE_CLASS = `${BUTTON_PRFX}mini-fab ${BUTTON_PRFX}fab`;
+                break;
+            default:
+                SHAPE_CLASS = null;
+                break;
+        }
         const COLOR_CLASS = color ? `${BUTTON_PRFX}${color}` : '';
         const JS_CLASS = isJs ? BTN_JS : '';
         const RIPPLE_EFFECT_CLASS = hasRipple ? RIPPLE_EFFECT : '';
@@ -80,36 +97,36 @@ const buttonMixin = {
         const {icon, iconLibrary} = this.props;
         switch (iconLibrary) {
             case 'material':
-                return <i className='material-icons'>{icon}</i>;
-            case 'font-awesome':
+            return <i className='material-icons'>{icon}</i>;
+                case 'font-awesome':
                 const faCss = `fa fa-${icon}`;
                 return <i className={faCss}></i>;
-            default:
+                    default:
+                    return null;
+                }
+            },
+            /**
+            * Render the label.
+            * @return {Component} - Tle button label.
+            */
+            _renderLabel () {
+                const {label, shape} = this.props;
+                if (label && 'fab' !== shape && 'icon' !== shape && 'mini-fab' !== shape ) {
+                    return this.i18n(label);
+                }
                 return null;
+            },
+            /** inheritedDoc */
+            render() {
+                const {id, type, label, style, ...otherProps} = this.props;
+                return (
+                    <button alt={this.i18n(label)} className={this._className()} data-focus="button-action" id={id} onClick={this.handleOnClick} style={style} title={this.i18n(label)} type={type} {...otherProps}>
+                        {this._renderIcon()}
+                        {this._renderLabel()}
+                    </button>
+                );
+            }
         }
-    },
-    /**
-    * Render the label.
-    * @return {Component} - Tle button label.
-    */
-    _renderLabel () {
-        const {label, shape} = this.props;
-        if (label && 'fab' !== shape && 'icon' !== shape && 'mini-fab' !== shape ) {
-            return this.i18n(label);
-        }
-        return null;
-    },
-    /** inheritedDoc */
-    render() {
-        const {id, type, label, style, ...otherProps} = this.props;
-        return (
-            <button alt={this.i18n(label)} className={this._className()} data-focus="button-action" id={id} onClick={this.handleOnClick} style={style} title={this.i18n(label)} type={type} {...otherProps}>
-                {this._renderIcon()}
-                {this._renderLabel()}
-            </button>
-        );
-    }
-}
-;
+        ;
 
-module.exports = builder(buttonMixin);
+        module.exports = builder(buttonMixin);


### PR DESCRIPTION
# [Button] Fixes #562 

## Fix classname given to the button when the `shape` prop is set to `'mini-fab'`

The classname is incomplete in case of `'mini-fab'`.

## Patch

Add the correct classes