### PR TITLE
Fix #590 date icon clik

### DIFF
--- a/src/common/input/date/style/date.scss
+++ b/src/common/input/date/style/date.scss
@@ -12,6 +12,7 @@
             top: 2px;
             right: 0;
             bottom: 0;
+            pointer-events: none;
         }
     }
 }


### PR DESCRIPTION
# [Date] Fixes #590  

## Add click on calendar icon

The calendar is not shown when the calendar icon is clicked.

![image](https://cloud.githubusercontent.com/assets/4435377/10659948/e1614196-78a3-11e5-876d-232ce2a504ff.png)

## Patch

Add the click on the icon, equivalent to the focus in the field.