### PR TITLE
Fix #480 search results props

### DIFF
--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -85,9 +85,9 @@ let Results = {
      */
     _renderSingleGroup(list, key, count, isUnique) {
         if(this.props.renderSingleGroupDecoration && !this.props.groupComponent) {
-            console.warn('You are trying to wrap your list in a group without a groupComponent. Please give one or set "renderSingleGroupDecoration" to false.');  
+            console.warn('You are trying to wrap your list in a group without a groupComponent. Please give one or set "renderSingleGroupDecoration" to false.');
         }
-        
+
         if (isUnique) {
             if (this.props.renderSingleGroupDecoration) {
                 return (
@@ -141,7 +141,8 @@ let Results = {
             lineOperationList,
             scrollParentSelector,
             selectionStatus,
-            selectionResultsMap
+            selectionResultsMap,
+            ...otherProps
         } = this.props;
         let selectionData = selectionResultsMap ? selectionResultsMap[key] || [] : [];
         let LineComponent = lineComponentMapper(key, list);
@@ -162,6 +163,7 @@ let Results = {
                     parentSelector={scrollParentSelector}
                     selectionData={selectionData}
                     selectionStatus={selectionStatus}
+                    {...otherProps}
                 />
                 {this.state.loading &&
                     <div data-focus='loading-more-results'>


### PR DESCRIPTION
# [Search results] Fixes #480 

## Other props not given to the list

In case custom props are given to the `results` component, they are not transfered to the list.

## Patch

Give the other props to the list component.