### PR TITLE
Fix #533 panel overlay

### DIFF
--- a/src/components/panel/style/panel.scss
+++ b/src/components/panel/style/panel.scss
@@ -36,6 +36,7 @@ $panel-border-size:3px;
     [data-focus='panel-content'] {
         &.mdl-card__supporting-text {
             width: auto;
+            overflow: inherit;
         }
     }
 


### PR DESCRIPTION
# [Panel] Fixes #533  

## Overflown elements are hidden at the panel bottom

These elements are cut.

## Patch

Inherit from parent overflow, so that these elements are displayed.