### PR TITLE
Fix #599 date custom getter

### DIFF
--- a/src/components/input/date/index.js
+++ b/src/components/input/date/index.js
@@ -17,6 +17,7 @@ const propTypes = {
     locale: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    beforeValueGetter: PropTypes.func.isRequired,
     placeHolder: PropTypes.string.isRequired,
     showDropdowns: PropTypes.bool.isRequired,
     validate: PropTypes.func,
@@ -32,6 +33,7 @@ const defaultProps = {
     drops: 'down',
     locale: 'en',
     format: 'MM/DD/YYYY',
+    beforeValueGetter: value => value,
     /**
     * Default onChange prop, that will log an error.
     */
@@ -140,7 +142,8 @@ class InputDate extends Component {
 
     getValue = () => {
         const {inputDate} = this.state;
-        return this._isInputFormatCorrect(inputDate) ? this._parseInputDate(inputDate).toISOString() : null;
+        const rawValue = this._isInputFormatCorrect(inputDate) ? this._parseInputDate(inputDate).toISOString() : null;
+        return this.props.beforeValueGetter(rawValue);
     }
 
     validate = () => {


### PR DESCRIPTION
# [Date] Fixes #599 

## No custom getter is possible

When calling the `getValue`, there should be a way to transform the value before it is sent to the server.

## Patch

The `InputDate` component now exposes a `beforeValueGetter` prop, which will be used when the `getValue` is called, taking the value as a parameter and returning whatever the user wants to send to the server.