### PR TITLE
[layout] publish layout header components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-components",
-  "version": "0.7.3",
+  "version": "0.7.4-rc1",
   "description": "Focus component repository.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-components",
-  "version": "0.7.4-rc1",
+  "version": "0.7.4-beta1",
   "description": "Focus component repository.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,13 +1,21 @@
+import headerActions from './layout/header-actions';
+import headerContent from './layout/header-content';
+import headerScrolling from './layout/header-scrolling';
+import headerTopRow from './layout/header-top-row';
 import input from './input';
-import panel from './panel';
-import scrollspyContainer from './scrollspy-container';
 import layout from './layout';
 import menuLeft from './menu';
+import panel from './panel';
+import scrollspyContainer from './scrollspy-container';
 
 export default {
+    HeaderActions: headerActions,
+    HeaderContent: headerContent,
+    HeaderScrolling: headerScrolling,
+    HeaderTopRow: headerTopRow,
     input,
-    Panel: panel,
-    ScrollspyContainer: scrollspyContainer,
     Layout: layout,
-    MenuLeft: menuLeft
+    MenuLeft: menuLeft,
+    Panel: panel,
+    ScrollspyContainer: scrollspyContainer
 }


### PR DESCRIPTION
# Layout

Header default components are now published in Focus-Components

![image](https://cloud.githubusercontent.com/assets/5349745/10697580/e756ba04-79ac-11e5-8562-30662a4c55f4.png)
