### PR TITLE
Fix #612 Popin should restore scrollbar

### DIFF
--- a/src/application/popin/index.js
+++ b/src/application/popin/index.js
@@ -49,6 +49,9 @@ const Overlay = React.createClass({
      */
     componentWillUnmount() {
         ReactDOM.findDOMNode(this.refs.overlay).removeEventListener('mousewheel', this._onScroll);
+        if (this._oldScroll !== undefined) {
+            this._restoreBodyOverflow();
+        }
     },
     /**
      * Mouse wheel event handler.


### PR DESCRIPTION
# [Popin] Fixes #612 

## Scrollbar is not restored on a route change

When changing the route without closing the window, the application scrollbar is not restored.

## Patch

The application scrollbar is now restored when the popin is opened and unmounted.