### PR TITLE
Fix #497 No configuration for initial rows count

### DIFF
--- a/src/page/search/common/component/group-wrapper.js
+++ b/src/page/search/common/component/group-wrapper.js
@@ -17,7 +17,7 @@ let GroupWrapper = {
     },
     getInitialState() {
         return ({
-            resultsDisplayedCount: 3
+            resultsDisplayedCount: this.props.initialRowsCount || 3
         });
     },
     _showMoreHandler() {

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -84,6 +84,7 @@ let Results = {
      * @return {HMTL}      the rendered group
      */
     _renderSingleGroup(list, key, count, isUnique) {
+        const {initialRowsCount} = this.props;
         if(this.props.renderSingleGroupDecoration && !this.props.groupComponent) {
             console.warn('You are trying to wrap your list in a group without a groupComponent. Please give one or set "renderSingleGroupDecoration" to false.');
         }
@@ -95,6 +96,7 @@ let Results = {
                         count={count}
                         groupComponent={this.props.groupComponent}
                         groupKey={key}
+                        initialRowsCount={initialRowsCount}
                         isUnique={true}
                         list={list}
                         renderResultsList={this._renderResultsList}
@@ -109,6 +111,7 @@ let Results = {
                     count={count}
                     groupComponent={this.props.groupComponent}
                     groupKey={key}
+                    initialRowsCount={initialRowsCount}
                     list={list}
                     renderResultsList={this._renderResultsList}
                     showAllHandler={this._showAllHandler}


### PR DESCRIPTION
## [Advanced search] No prop for `initialRowsCount`

It was not possible to set an initial rows count in the groups of the advanced search component.

## Patch

Add the `initialRowsCount` prop.