### PR TITLE
Fix #633 Search header should expose more props

### DIFF
--- a/src/page/search/search-header/mixin/index.js
+++ b/src/page/search/search-header/mixin/index.js
@@ -51,12 +51,19 @@ module.exports = {
         }
     },
     _SearchBarComponent() {
-        return <SearchBar
-            ref='searchBar'
-            scopes={this.state.reference.scopes}
-            loading={this.state.isLoading}
-            action={this._action}
-            store={advancedSearchStore}
-            />;
+        const {helpTranslationPath, minChar, placeholder} = this.props;
+        const {isLoading, reference: {scopes}} = this.state;
+        return (
+            <SearchBar
+                action={this._action}
+                helpTranslationPath={helpTranslationPath}
+                loading={isLoading}
+                minChar={minChar}
+                placeholder={placeholder}
+                ref='searchBar'
+                scopes={scopes}
+                store={advancedSearchStore}
+                />
+        );
     }
 };


### PR DESCRIPTION
# [Search header] Fixes #633 

## Search header hides props for the search bar

Some of the search bar props are not exposed by the search header.

## Patch

More props have been added.