### PR TITLE
Fix #548 Scroll spy sees popin contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-components",
-  "version": "0.7.3-3",
+  "version": "0.7.3-4",
   "description": "Focus component repository.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/scrollspy-container/index.js
+++ b/src/components/scrollspy-container/index.js
@@ -102,19 +102,30 @@ class ScrollspyContainer extends Component {
         }
         const currentScrollPosition = this.scrollPosition();
 
-        //get menu list
-        const selectionList = document.querySelectorAll('[data-spy]');
+        //get menu list$
+        const thisReactId = ReactDOM.findDOMNode(this).getAttribute('data-reactid');
+        const selectionList = Array.prototype.slice.call(document.querySelectorAll('[data-spy]')).filter(element => {
+            let cursorElement = element;
+            let isInPopin = false;
+            while (cursorElement.getAttribute('data-reactid') !== thisReactId && !isInPopin) {
+                cursorElement = cursorElement.parentElement;
+                if (cursorElement.getAttribute('data-focus') === 'popin-window') {
+                    isInPopin = true;
+                }
+            }
+            return !isInPopin;
+        });
         if(selectionList.length === 0) {
             return;
         }
-        const menuList = [].map.call(selectionList, (selection, index) => {
+        const menuList = selectionList.map((selection, index) => {
             const title = selection.querySelector('[data-spy-title]');
             const nodeId = selection.getAttribute('data-spy');
             return {
                 index: index,
                 label: title.innerHTML,
                 nodeId: nodeId,
-                offsetTop: selection.offsetTop, // offset of 10 to ensure
+                offsetTop: selection.offsetTop, // offset of 10 to be safe
                 isActive: false,
                 onClick: this._handleMenuItemClick(nodeId)
             };


### PR DESCRIPTION
## [Scroll spy] Popin are explored

When looking for `Panels` to build the sticky menu, the `scrollSpyContainer` goes too deep in the DOM and sees the `Popins`. It souldn't explore there content.

![image](https://cloud.githubusercontent.com/assets/4435377/10906285/8885bfc6-8220-11e5-9126-86caa5497942.png)

## Patch

When building the menu, the `scrollSpyContainer` now checks whether there is a `Popin` component between itself and the target `Panel`.

![image](https://cloud.githubusercontent.com/assets/4435377/10906388/6c4e1cb2-8221-11e5-9daa-c4748b490881.png)
