### PR TITLE
Fix #553 dev bar should have a prod mode

### DIFF
--- a/src/application/layout/index.js
+++ b/src/application/layout/index.js
@@ -22,15 +22,16 @@ const contentActionsMixin = {
             LoadingBar: LoadingBarDefault,
             MessageCenter: MessageCenterDefault,
             ErrorCenter: ErrorCenterDefault,
+            displayDevBar: true,
             footerText: 'Please override the footer text by giving a "footerText" property to the Layout component.'
         };
     },
     /** inheriteddoc */
     render() {
-        const {LoadingBar, MessageCenter, ErrorCenter, AppHeader, MenuLeft, footerText, children} = this.props;
+        const {LoadingBar, MessageCenter, ErrorCenter, AppHeader, MenuLeft, footerText, displayDevBar, children} = this.props;
         return (
             <div className={this._getStyleClassName()} data-focus='layout'>
-                <LoadingBar />
+                <LoadingBar displayDevBar={displayDevBar} />
                 <MessageCenter />
                 <ErrorCenter />
                 <AppHeader />

--- a/src/application/loading-bar/index.js
+++ b/src/application/loading-bar/index.js
@@ -33,6 +33,7 @@ let LoadingBarMixin = {
     render: function renderProgressBar() {
         var completed  = +((this.state.total - this.state.pending)/this.state.total)*100;
         var visible = false;
+        const {displayDevBar} = this.props;
         if(completed < 100){
             visible = true;
         }
@@ -40,13 +41,15 @@ let LoadingBarMixin = {
         return (
             <div data-focus='loading-bar'>
                 {visible && <ProgressBar completed={completed} />}
-                <ul className='fa-ul'>
-                    <li><Icon name='swap_vert'/> pending {this.state.pending}</li>
-                    <li><Icon name='not_interested'/> cancelled {this.state.cancelled}</li>
-                    <li><Icon name='check_circle'/> success {this.state.success}</li>
-                    <li><Icon name='error'/> error {this.state.error}</li>
-                    <li><Icon name='functions'/> total {this.state.total}</li>
-                </ul>
+                {displayDevBar &&
+                    <ul className='fa-ul'>
+                        <li><Icon name='swap_vert'/> pending {this.state.pending}</li>
+                        <li><Icon name='not_interested'/> cancelled {this.state.cancelled}</li>
+                        <li><Icon name='check_circle'/> success {this.state.success}</li>
+                        <li><Icon name='error'/> error {this.state.error}</li>
+                        <li><Icon name='functions'/> total {this.state.total}</li>
+                    </ul>
+                }
             </div>
         );
     }


### PR DESCRIPTION
## [Dev bar] Hide in production mode

When building a production version of an app, the dev bar should be hidden.

## Patch

The `Layout` component now has a `displayDevBar` prop, by default set to `true`.
To hide the dev bar, simply set it to `false`.

```javascript
<Layout
    // ...
    displayDevBar={false}
    // ...
```

Fixes #553