### PR TITLE
[panel] display action permanently when form is edit

### DIFF
--- a/src/components/panel/style/panel.scss
+++ b/src/components/panel/style/panel.scss
@@ -50,5 +50,8 @@ $panel-border-size:3px;
 [data-mode="edit"] {
     [data-focus='panel'] {
         border:$panel-border-size solid $panel-title-color;
+        .actions {
+            display: block;
+        }
     }
 }


### PR DESCRIPTION
# [panel] display action permanently when form is edit

## Issue Description

In a panel inside a form :

The Edit button appears only when the mouse is over the panel => OK
I click the Edit button and switch to edition mode => OK
The buttons are now Save and Cancel => OK
The buttons disappears when the mouse it out the panel => KO

![buttonbardisappear](https://cloud.githubusercontent.com/assets/9380855/10937429/0b06bb30-82f3-11e5-9a00-b9ac6cc0d842.gif)

> Fixes #641 

## Patch

Now display action permanently when form is edited.