### PR TITLE
Fix #650 select has undefined

### DIFF
--- a/src/components/input/select/index.js
+++ b/src/components/input/select/index.js
@@ -69,7 +69,8 @@ class Select extends Component {
     }
     /** inheritdoc */
     _renderOptions({hasUndefined, labelKey, isRequired, value, values = [], valueKey}){
-        if(true === hasUndefined || (true === isRequired && !isUndefined(value) && !isNull(value))){
+        const isRequiredAndNoValue = isRequired && (isUndefined(value) || isNull(value));
+        if(hasUndefined || isRequiredAndNoValue){
             values = union(
                 [{[labelKey]: this.i18n('select.unSelected'), [valueKey]: UNSELECTED_KEY}],
                 values


### PR DESCRIPTION
## [Select] Fix condition for undefined value

The condition for having the possibility not to select a value was wrong.

## Patch

It is now fixed. A select can have an undefined value if the `hasUndefined` property is set to `true`, or if the `isRequired` prop is set to `true` and the select does not have a value yet (in case of data creation).

Fixes #650