### PR TITLE
Fix #667 ref to the list in a list page

### DIFF
--- a/src/page/list/index.js
+++ b/src/page/list/index.js
@@ -101,7 +101,7 @@ let listPageMixin = {
     /** @inheritdoc */
     render(){
         let listProps = this._buildListProps();
-        return <this.props.ListComponent {...listProps} />;
+        return <this.props.ListComponent {...listProps} ref='list'/>;
     }
 };
 


### PR DESCRIPTION
# Missing ref to the list in a list page

## Patch

Add a ref called `'list`