### PR TITLE
[lifecycle] Fix all misspelling names

### DIFF
--- a/src/application/bar/index.js
+++ b/src/application/bar/index.js
@@ -21,7 +21,7 @@ const barMixin = {
     /**
     * Component will unmount.
     */
-    componentWillUnMount() {
+    componentWillUnmount() {
         applicationStore.removeSummaryComponentChangeListener(this._handleComponentChange);
         applicationStore.removeBarContentLeftComponentChangeListener(this._handleComponentChange);
         applicationStore.removeBarContentRightComponentChangeListener(this._handleComponentChange);

--- a/src/application/cartridge/index.js
+++ b/src/application/cartridge/index.js
@@ -12,7 +12,7 @@ const cartridgeMixin = {
         applicationStore.addCartridgeComponentChangeListener(this._handleComponentChange);
     },
     /** @inheriteddoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         applicationStore.removeCartridgeComponentChangeListener(this._handleComponentChange);
     },
     /**

--- a/src/application/content-actions/index.js
+++ b/src/application/content-actions/index.js
@@ -26,7 +26,7 @@ const ContentActions = {
         applicationStore.addActionsChangeListener(this._handleComponentChange);
     },
     /** @inheriteddoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         applicationStore.removeActionsChangeListener(this._handleComponentChange);
     },
     /**

--- a/src/application/header/index.js
+++ b/src/application/header/index.js
@@ -76,7 +76,7 @@ const headerMixin = {
         this.attachScrollListener();
     },
     /** @inheriteddoc */
-    componentWillUnMount: function barWillUnMount(){
+    componentWillUnmount: function barWillUnMount(){
         this.detachScrollListener();
         this.appStateWillUnmount();
     },

--- a/src/application/loading-bar/index.js
+++ b/src/application/loading-bar/index.js
@@ -16,7 +16,7 @@ let LoadingBarMixin = {
         requestStore.addClearRequestsListener(this._handleClearRequests);
     },
     /** @inheriteddoc */
-    componentWillUnMount: function cartridgeWillUnMount(){
+    componentWillUnmount: function cartridgeWillUnMount(){
         requestStore.removeUpdateRequestListener(this._handleRequestsUpdate);
         requestStore.removeClearRequestsListener(this._handleClearRequests);
     },

--- a/src/application/message-center/index.js
+++ b/src/application/message-center/index.js
@@ -23,7 +23,7 @@ var messageCenterMixin = {
     messageStore.addClearMessagesListener(this._handleClearMessage);
   },
   /** @inheriteddoc */
-  componentWillUnMount: function cartridgeWillUnMount(){
+  componentWillUnmount: function cartridgeWillUnMount(){
     messageStore.removePushedMessageListener(this._handlePushMessage);
     messageStore.removeClearMessagesListener(this._handleClearMessage);
   },

--- a/src/common/button/back-to-top/index.js
+++ b/src/common/button/back-to-top/index.js
@@ -46,7 +46,7 @@ const backToTopMixin = {
         this._scrollCarrier.addEventListener('resize', this._scrollSpy);
         this._scrollSpy();
     },
-    componentWillUnMount() {
+    componentWillUnmount() {
         this._scrollCarrier.removeEventListener('scroll', this._scrollSpy);
         this._scrollCarrier.removeEventListener('resize', this._scrollSpy);
     },

--- a/src/common/scrollspy/index.js
+++ b/src/common/scrollspy/index.js
@@ -53,7 +53,7 @@ const Scrollspy = {
         this._scrollSpy();
     },
     /** @inheritDoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         this._scrollCarrier.removeEventListener('scroll', this._scrollSpy);
         this._scrollCarrier.removeEventListener('resize', this._scrollSpy);
     },

--- a/src/components/layout/header-actions.js
+++ b/src/components/layout/header-actions.js
@@ -31,7 +31,7 @@ class HeaderActions extends Component {
     }
 
     /** @inheriteddoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         applicationStore.removeActionsChangeListener(this._handleComponentChange);
     }
 

--- a/src/components/layout/header-content.js
+++ b/src/components/layout/header-content.js
@@ -25,7 +25,7 @@ class HeaderContent extends Component {
     }
 
     /** @inheriteddoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         applicationStore.removeCartridgeComponentChangeListener(this._handleComponentChange);
     }
 

--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -77,7 +77,7 @@ class HeaderScrolling extends Component {
     }
 
     /** @inheriteddoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         this.scrollTargetNode.removeEventListener('scroll', this.handleScroll);
         this.scrollTargetNode.removeEventListener('resize', this.handleScroll);
         applicationStore.removeModeChangeListener(this._handleChangeApplicationStatus);

--- a/src/components/layout/header-top-row.js
+++ b/src/components/layout/header-top-row.js
@@ -28,7 +28,7 @@ class HeaderTopRow extends Component {
     }
 
     /** @inheriteddoc */
-    componentWillUnMount() {
+    componentWillUnmount() {
         applicationStore.removeSummaryComponentChangeListener(this._handleComponentChange);
         applicationStore.removeBarContentLeftComponentChangeListener(this._handleComponentChange);
         applicationStore.removeBarContentRightComponentChangeListener(this._handleComponentChange);

--- a/src/page/list/index.js
+++ b/src/page/list/index.js
@@ -110,7 +110,7 @@ let listPageMixin = {
         this._buildAction();
         this._action.load();
     },
-    componentWillUnMount(){
+    componentWillUnmount(){
         this._unRegisterStoreNode();
     },
     /** @inheritdoc */


### PR DESCRIPTION
# Fix lifecycle names

## Description

Thanks to @Jerom138 with #700 which reveals an important misspelling on `componentWillUnMount ` which should have been `componentWillUnmount `.

The lifecycle methods are described [here](https://facebook.github.io/react/docs/component-specs.html)

We check all the names :

## Problems found

- `componentWillUnmount ` (13 errors were `componentWillUnMount `)

## Methods without problems

- `getInitialState`
- `getDefaultProps`
- `propTypes`
- `mixins`
- `displayName`
- `componentDidMount`
- `componentWillReceiveProps`
- `componentDidUpdate`

## Not used
- `shouldComponentUpdate `


It fixes #701 and close #700 