### PR TITLE
[memory list] Add a list ref on the component

### DIFF
--- a/src/common/list/index.js
+++ b/src/common/list/index.js
@@ -21,6 +21,7 @@ let MemoryListMixin = {
         var childProps = omit(this.props, ['lineComponent', 'data']);
         return (
             <this.props.listComponent
+                ref='list'
                 data={this.getDataToUse()}
                 hasMoreData={hasMoreData}
                 LineComponent={this.props.LineComponent}


### PR DESCRIPTION
# Memory list

## Description

Add a ref `list` on the `MemoryListComponent` in order to allow 
```javascript
//Example
this.refs['myListForComponentPropertyName'].refs.list.getSelectedItems()

```