### PR TITLE
[Select] Mandatory check fails on id select value

### DIFF
--- a/src/components/input/select/index.js
+++ b/src/components/input/select/index.js
@@ -12,14 +12,12 @@ const UNSELECTED_KEY = 'UNSELECTED_KEY';
  * @return {strint | number}  - The parsed value.
  */
 function _valueParser(propsValue, rawValue) {
-    function _valueParser(propsValue, rawValue) {
-		if(UNSELECTED_KEY === rawValue) {
-			return undefined;
-		}
-	    return _lodashLang.isNumber(propsValue) ? +rawValue : rawValue;
+	if(UNSELECTED_KEY === rawValue) {
+		return undefined;
 	}
     return isNumber(propsValue) ? +rawValue : rawValue;
 }
+return isNumber(propsValue) ? +rawValue : rawValue;
 const propTypes = {
     disabled: PropTypes.bool,
     error: PropTypes.string,

--- a/src/components/input/select/index.js
+++ b/src/components/input/select/index.js
@@ -12,6 +12,12 @@ const UNSELECTED_KEY = 'UNSELECTED_KEY';
  * @return {strint | number}  - The parsed value.
  */
 function _valueParser(propsValue, rawValue) {
+    function _valueParser(propsValue, rawValue) {
+		if(UNSELECTED_KEY === rawValue) {
+			return undefined;
+		}
+	    return _lodashLang.isNumber(propsValue) ? +rawValue : rawValue;
+	}
     return isNumber(propsValue) ? +rawValue : rawValue;
 }
 const propTypes = {


### PR DESCRIPTION
If the component has already a value (int type), and we change the value to null, the functions retuns NaN, and it should returns undefined