### PR TITLE
[autocomplete] Fix getValue in consult mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-components",
-  "version": "0.7.7-alpha1",
+  "version": "0.7.7-alpha2",
   "description": "Focus component repository.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/common/autocomplete/field.js
+++ b/src/common/autocomplete/field.js
@@ -78,8 +78,9 @@ const AutocompleteFor = {
      * @return {string} the code of the curren value
      */
     getValue() {
-        let {autocomplete} = this.refs;
-        return autocomplete ? autocomplete.getValue() : this.state.value;
+        const {autocomplete} = this.refs;
+        const {allowUnmatchedValue, value} = this.props;
+        return autocomplete ? autocomplete.getValue() : allowUnmatchedValue ? this.state.value : value;
     },
     /**
      * Render the edit mode


### PR DESCRIPTION
# Fix `getValue`

## Description

The `getValue` method returns the label instead of the code when the field has `isEdit` set to `false`.

## Patch

Check if `allowUnmatchedValue` is set to `false`, and if yes then return the code.