### PR TITLE
[radio] Fix material look when provided value changes

### DIFF
--- a/src/common/input/radio/index.js
+++ b/src/common/input/radio/index.js
@@ -39,6 +39,15 @@ const radioMixin = {
             isChecked: isUndefined(value) ? false : value
         };
     },
+    componentDidUpdate() {
+        const {inputMdl} = this.refs;
+        const {isChecked} = this.state;
+        if (inputMdl) {
+            const {classList} = inputMdl;
+            const method = isChecked ? 'add' : 'remove'
+            classList[method]('is-checked');
+        }
+    },
     /**
     * Executed actions on change event.
     * @param  {event} event
@@ -70,7 +79,7 @@ const radioMixin = {
         const checkedProps = isChecked ? {checked: 'checked'} : {};
         const inputProps = {...{className: 'mdl-radio__button', name: name, onChange: this._onChange, type: 'radio'}, ...checkedProps};
         return (
-            <label className='mdl-radio mdl-js-radio mdl-js-ripple-effect' data-focus="input-radio">
+            <label className='mdl-radio mdl-js-radio mdl-js-ripple-effect' data-focus="input-radio" ref='inputMdl'>
                 <input {...inputProps} />
                 <span className='mdl-radio__label'>{this.i18n(label)}</span>
             </label>


### PR DESCRIPTION
# Fix radio select display issue when provided changing value

## Description

The display is broken when the value comes after the initial render.

## Patch

Now adjusting the `is-checked` class in the DOM to trigger the correct MDL display.

Fixes #670 