### PR TITLE
[reference] Create a new object action in the form to avoid shared re…

### DIFF
--- a/src/common/form/mixin/reference-behaviour.js
+++ b/src/common/form/mixin/reference-behaviour.js
@@ -22,8 +22,10 @@ const referenceMixin = {
     * Build actions associated to the reference.
     */
     _buildReferenceActions(){
-        this.action = this.action || {};
-        this.action.loadReference = builtInActionReferenceLoader(this.referenceNames);
+        this.action = {
+            loadReference: builtInActionReferenceLoader(this.referenceNames),
+            ...this.action
+        };
     },
     _loadReference(){
         return this.action.loadReference();


### PR DESCRIPTION
# Fix the form action 

## Description

Create a new object action in the form to avoid shared reference between forms. Fix #731 .