### PR TITLE
[Scrollspy] Fix scrollspy responsive issues. fixes #712.

### DIFF
--- a/src/components/layout/style/header-scrolling.scss
+++ b/src/components/layout/style/header-scrolling.scss
@@ -43,7 +43,6 @@ to { height: auto; }
 
     [data-focus="header-actions"] {
         display: inline;
-        margin-right: 200px;
     }
 
     //When the size is medium, the summary-bar is not visible.
@@ -91,6 +90,27 @@ to { height: auto; }
                     }
                 }
             }
+        }
+    }
+}
+
+// TODO: put this variable in a global variable.scss
+$media-tablet-breakpoint: 480px !default;
+$media-desktop-breakpoint: 840px !default;
+
+
+@media (max-width: $media-desktop-breakpoint - 1) {
+    [data-focus='header-scrolling'] {
+        [data-focus="header-actions"] {
+            margin-right: 20px;
+        }
+    }
+}
+
+@media (min-width: $media-desktop-breakpoint - 1) {
+    [data-focus='header-scrolling'] {
+        [data-focus="header-actions"] {
+            margin-right: 200px;
         }
     }
 }

--- a/src/components/scrollspy-container/index.js
+++ b/src/components/scrollspy-container/index.js
@@ -16,8 +16,8 @@ const defaultProps = {
     hasMenu: true, //Activate the presence of the sticky navigation component.
     hasBackToTop: true, //Activate the presence of BackToTop button
     offset: 80, //offset position when affix
-    gridMenuSize: 3, //default grid size of the menu
-    gridContentSize: 9, //default content size of the menu
+    //gridMenuSize: 3, //default grid size of the menu
+    //gridContentSize: 9, //default content size of the menu
     scrollDelay: 10 //defaut debounce delay for scroll spy call
 };
 
@@ -26,8 +26,8 @@ const propTypes = {
     hasMenu: PropTypes.bool,
     hasBackToTop: PropTypes.bool,
     offset: PropTypes.number,
-    gridMenuSize: PropTypes.number,
-    gridContentSize: PropTypes.number,
+    //gridMenuSize: PropTypes.number,
+    //gridContentSize: PropTypes.number,
     scrollDelay: PropTypes.number
 };
 
@@ -176,10 +176,7 @@ class ScrollspyContainer extends Component {
             return false;
         }
         const currentScrollPosition = this.scrollPosition();
-        const menu = ReactDOM.findDOMNode(this.refs.stickyMenu);
-        const menuTopPosition = menu.offsetTop;
-        return menuTopPosition < currentScrollPosition.top + offset;
-
+        return currentScrollPosition.top > offset;
     }
 
     /**
@@ -213,20 +210,17 @@ class ScrollspyContainer extends Component {
         let {gridContentSize} = this.props;
         gridContentSize = hasMenu ? gridContentSize : 12;
         return (
-
-            <Grid data-focus='scrollspy-container' {...otherProps}>
+            <div data-focus='scrollspy-container' {...otherProps}>
                 {hasMenu &&
-                    <Column size={gridMenuSize}>
-                        <StickyMenu affix={affix} affixOffset={offset} menuList={menuList} ref="stickyMenu" />
-                    </Column>
+                    <StickyMenu affix={affix} affixOffset={offset} menuList={menuList} ref="stickyMenu" />
                 }
-                <Column data-focus='scrollspy-container-content' size={gridContentSize}>
+                <div data-focus='scrollspy-container-content'>
                     {children}
-                </Column>
+                </div>
                 {hasBackToTop &&
                     <BackToTopComponent />
                 }
-            </Grid>
+            </div>
         );
     }
 }

--- a/src/components/scrollspy-container/index.js
+++ b/src/components/scrollspy-container/index.js
@@ -16,8 +16,6 @@ const defaultProps = {
     hasMenu: true, //Activate the presence of the sticky navigation component.
     hasBackToTop: true, //Activate the presence of BackToTop button
     offset: 80, //offset position when affix
-    //gridMenuSize: 3, //default grid size of the menu
-    //gridContentSize: 9, //default content size of the menu
     scrollDelay: 10 //defaut debounce delay for scroll spy call
 };
 
@@ -26,8 +24,6 @@ const propTypes = {
     hasMenu: PropTypes.bool,
     hasBackToTop: PropTypes.bool,
     offset: PropTypes.number,
-    //gridMenuSize: PropTypes.number,
-    //gridContentSize: PropTypes.number,
     scrollDelay: PropTypes.number
 };
 

--- a/src/components/scrollspy-container/sticky-menu.js
+++ b/src/components/scrollspy-container/sticky-menu.js
@@ -3,7 +3,7 @@ import React, {Component, PropTypes} from 'react';
 // component default props.
 const defaultProps = {
     affix: false,
-    affixOffset: 100,
+    affixOffset: 0,
     menuList: []
 };
 
@@ -25,7 +25,7 @@ class StickyMenu extends Component {
     render() {
         const {affix, affixOffset, menuList, ...otherProps} = this.props;
         return (
-            <nav data-affix={affix} data-focus='sticky-menu' style={affix ? {position: 'fixed', top: `${affixOffset}px`} : null} {...otherProps}>
+            <nav data-affix={affix} data-focus='sticky-menu' data-offset={affixOffset} {...otherProps}>
                 <ul>
                     {menuList.map((menu)=>{
                         const {label, nodeId, isActive, onClick} = menu;

--- a/src/components/scrollspy-container/style/scrollspy-container.scss
+++ b/src/components/scrollspy-container/style/scrollspy-container.scss
@@ -1,5 +1,44 @@
+$scrollspy-container-menu-size:220px;
+
+// TODO: put this variable in a global variable.scss
+$media-tablet-breakpoint: 480px !default;
+$media-desktop-breakpoint: 840px !default;
+
+//TODO: put this in a global css attribute.
+//possible offset
+@mixin position-offset-top($position-offset-top-max) {
+    @while $position-offset-top-max > 0 {
+        &[data-offset="#{$position-offset-top-max}"] {top: #{$position-offset-top-max}px; }
+        $position-offset-top-max: $position-offset-top-max - 1;
+    }
+}
+
+[data-focus="scrollspy-container"] {
+    padding:10px;
+    position: relative;
+}
 
 
-[data-focus='scrollspy-container'] {
-    //css to override
+@media (max-width: $media-desktop-breakpoint - 1) {
+    [data-focus="scrollspy-container"] {
+        [data-focus="sticky-menu"] {
+            margin-bottom: 20px;
+        }
+    }
+}
+
+@media (min-width: $media-desktop-breakpoint - 1) {
+    [data-focus="scrollspy-container"] {
+        [data-focus="sticky-menu"] {
+            width: $scrollspy-container-menu-size;
+            position: absolute;
+            &[data-affix="true"] {
+                position: fixed;
+                @include position-offset-top(150);
+            }
+        }
+        [data-focus="scrollspy-container-content"] {
+            margin-left: #{$scrollspy-container-menu-size + 10px};
+        }
+    }
 }

--- a/src/components/scrollspy-container/style/scrollspy-container.scss
+++ b/src/components/scrollspy-container/style/scrollspy-container.scss
@@ -1,4 +1,4 @@
-$scrollspy-container-menu-size:220px;
+$scrollspy-container-menu-size:260px;
 
 // TODO: put this variable in a global variable.scss
 $media-tablet-breakpoint: 480px !default;

--- a/src/components/scrollspy-container/style/sticky-menu.scss
+++ b/src/components/scrollspy-container/style/sticky-menu.scss
@@ -1,16 +1,9 @@
-$scrollpsy-size:200px;
-$scrollpsy-content-padding:10px;
-$scrollpsy-font-size: 14px;
-$scrollpsy-active-font-size: 18px;
-$scrollpsy-active-color:#36b7b9;
+$sticky-menu-font-size: 14px;
+$sticky-menu-active-font-size: 18px;
+$sticky-menu-active-color:#36b7b9;
+
 
 [data-focus="sticky-menu"] {
-    float:left;
-    width: $scrollpsy-size;
-    & + div {
-        margin-left: $scrollpsy-size;
-        padding:$scrollpsy-content-padding;
-    }
     ul {
         margin: 0;
         padding: 0;
@@ -20,21 +13,20 @@ $scrollpsy-active-color:#36b7b9;
             color:black;
             border-left: 5px solid transparent;
             line-height: 20px;
-            font-size: $scrollpsy-font-size;
+            font-size: $sticky-menu-font-size;
             color:#848484;
             cursor: pointer;
             background-color: transparent;
-            transition: background-color 1s linear;
+            transition: background-color 0.3s linear;
             list-style: none;
-
             &:hover {
                 background-color: #EAEAEA;
             }
 
             &[data-active="true"] {
-                border-color: $scrollpsy-active-color;
-                color: $scrollpsy-active-color;
-                font-size: $scrollpsy-active-font-size;
+                border-color: $sticky-menu-active-color;
+                color: $sticky-menu-active-color;
+                font-size: $sticky-menu-active-font-size;
             }
         }
     }


### PR DESCRIPTION
## Issue Description

Scrollspy-content and menu were are not well displayed on mobiles.

![image](https://cloud.githubusercontent.com/assets/5349745/11345427/2389ad60-9217-11e5-92d1-4aa8ca3bc89e.png)

> Fixes #712 

## Patch

This patch gives a first answer to responsive problems.

> Be careful, these changes may have some impact on your project. But don't worry, it's quite easy to change it ! It is described below.

### widescreen size and tablet size

MDL grid are not used anymore, so the allocated size of scrollspy menu remains the same if the windows size change.

<img width="1440" alt="capture d ecran 2015-11-29 a 17 22 13" src="https://cloud.githubusercontent.com/assets/5349745/11458314/c0d7e96a-96bd-11e5-9dbd-82157b5b5e20.png">

### mobile size

On mobile screens, scrollspy menu is not displayed anymore on the left but at the top of the content.

<img width="1440" alt="capture d ecran 2015-11-29 a 17 23 50" src="https://cloud.githubusercontent.com/assets/5349745/11458335/fc757758-96bd-11e5-8601-e4a1764cfb56.png">

## To modify scrollspy menu width

The default size of the menu is 260px. It's maybe not what your project needs.
That's why you can override this default size by addeing the following CSS code in your `scrollspy-container.scss` SASS file:

```sass
$scrollspy-container-menu-size:220px;
$media-desktop-breakpoint: 840px !default;

@media (min-width: $media-desktop-breakpoint - 1) {
    [data-focus="scrollspy-container"] {
        [data-focus="sticky-menu"] {
            width: $scrollspy-container-menu-size;
        }
        [data-focus="scrollspy-container-content"] {
            margin-left: #{$scrollspy-container-menu-size + 10px};
        }
    }
}
```

