### PR TITLE
[header] fix zigwigwigwi

### DIFF
--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -137,11 +137,18 @@ class HeaderScrolling extends Component {
         const {size} = this.state;
         const currentIndex = this.sizes.indexOf(size);
         const currentScrollPosition = this.scrollPosition();
-        //Process increase treatement.
-        if(currentIndex < (this.sizes.length - 1)) {
-            const increaseBorder = this.props.sizeMap[this.sizes[currentIndex + 1]].sizeBorder;
-            if(currentScrollPosition.top > increaseBorder) {
-                return this._changeSize(this.sizes[currentIndex + 1]);
+
+        const node = ReactDom.findDOMNode(this);
+        const bodyNode = document.body;
+        const value = bodyNode.scrollHeight - node.scrollHeight - bodyNode.clientHeight;
+
+        if(value > 0) {
+            //Process increase treatement.
+            if(currentIndex < (this.sizes.length - 1)) {
+                const increaseBorder = this.props.sizeMap[this.sizes[currentIndex + 1]].sizeBorder;
+                if(currentScrollPosition.top > increaseBorder) {
+                    return this._changeSize(this.sizes[currentIndex + 1]);
+                }
             }
         }
         //Process decrease treatement.
@@ -151,6 +158,7 @@ class HeaderScrolling extends Component {
                 return this._changeSize(this.sizes[currentIndex - 1]);
             }
         }
+
     }
 
     /**


### PR DESCRIPTION
## Issue Description

When body scrollHeight is a little bigger than body clientHeight, weird phenomena commonly called "Zigwigwi" appeared.

![zigwigwi](https://cloud.githubusercontent.com/assets/9960528/10643263/37eb795a-7822-11e5-8d8c-7ba728388ef5.gif)

> Fixes #164

## Patch

To avoid this behaviour, shrink of header is not applied conditionnally to body height and header height. calculation is the following:

```javascript
  const node = ReactDom.findDOMNode(this);
  const bodyNode = document.body;
  const value = bodyNode.scrollHeight - node.scrollHeight - bodyNode.clientHeight;
  if(value > 0) {
    //shrink the header
  }
```

This seems to correct the zigwigwigwi behaviour.
This was tested on the focus demo app, and this correction worked. Please make us some feed back.