### PR TITLE
[autocomplete] Cannot unselect an autocomplete

### DIFF
--- a/src/common/autocomplete/awesomplete.js
+++ b/src/common/autocomplete/awesomplete.js
@@ -157,6 +157,7 @@ let Autocomplete = {
     */
     getValue() {
         const {value} = this.state;
+        if (value === '') return null;
         const {allowUnmatchedValue} = this.props;
         const computedValue = this._getCodeFromValue(value);
         return computedValue ? computedValue : allowUnmatchedValue ? value : this.props.code;


### PR DESCRIPTION
## Description

It is not possible to unselect a value in the autocomplete component.

## Patch

It is now possible.

Fixes #749