### PR TITLE
[behaviour] Feature definition behaviour

### DIFF
--- a/src/behaviours/definition/__tests__/definition-behaviour-test.js
+++ b/src/behaviours/definition/__tests__/definition-behaviour-test.js
@@ -71,6 +71,27 @@ describe('The definition behaviour', () => {
         it('shoud not throw an error when the param is a string and in the definition map',  () => {
             expect(() => DefinitionBehaviour('contact')).to.not.throw(Error);
         });
+        it.only('Annotation test', () => {
+
+
+            class TestComponent extends React.Component {
+                render() {
+                    return (
+                        <div ref='myRef'>
+                            {this.props.test}
+                        </div>
+                    );
+                }
+            }
+
+			const CompWithDef = DefinitionBehaviour('contact')(TestComponent);
+			console.log('CompWithDef')
+			console.log(CompWithDef)
+            const renderedComponent = TestUtils.renderIntoDocument(<CompWithDef test='hello'/>);
+            console.log(renderedComponent);
+            expect(renderedComponent.props).to.have.property('contact')
+
+        })
         /*before(() => {
             @DefinitionBehaviour('contact')
             class TestComponent extends React.Component {

--- a/src/behaviours/definition/__tests__/definition-behaviour-test.js
+++ b/src/behaviours/definition/__tests__/definition-behaviour-test.js
@@ -74,8 +74,9 @@ describe('The definition behaviour', () => {
         it('shoud not throw an error when the param is a string and in the definition map',  () => {
             expect(() => DefinitionBehaviour('contact')).to.not.throw(Error);
         });
-        it('Annotation test', () => {
-
+	  });
+	  describe('when called with a correct definition path', () => {
+        it('should add a defintion property', () => {
 		    class TestComponent extends React.Component {
                 render() {
 					return (
@@ -87,9 +88,23 @@ describe('The definition behaviour', () => {
             }
 			const CompWithDef = DefinitionBehaviour('contact')(TestComponent);
             const renderedComponent = TestUtils.renderIntoDocument(<CompWithDef test='hello'/>);
-			expect(renderedComponent.refs.wrappedComponent.props).to.have.property('definition')
-
-        })
+			expect(renderedComponent.refs.wrappedComponent.props).to.have.property('definition');
+        });
+		it('should contains all the property given as definition', () => {
+		    class TestComponent extends React.Component {
+                render() {
+					return (
+                        <div ref='myRef'>
+                            {JSON.stringify(this.props)}
+                        </div>
+                    );
+                }
+            }
+			const CompWithDef = DefinitionBehaviour('contact')(TestComponent);
+            const renderedComponent = TestUtils.renderIntoDocument(<CompWithDef test='hello'/>);
+			expect(renderedComponent.refs.wrappedComponent.props.definition)
+				  .to.have.property('firstName');
+        });
         /*before(() => {
             @DefinitionBehaviour('contact')
             class TestComponent extends React.Component {

--- a/src/behaviours/definition/__tests__/definition-behaviour-test.js
+++ b/src/behaviours/definition/__tests__/definition-behaviour-test.js
@@ -1,0 +1,93 @@
+import DefinitionBehaviour from '../';
+import {definition} from 'focus-core';
+const DOMAIN = {
+	DO_TEXT: {
+		style: "do_text",
+		type: "text",
+		component: "PapaSinge",
+		validation: [{
+			type: "function",
+			value: function() {
+				return false;
+			}
+		}]
+	},
+	DO_EMAIL: {
+		style: "do_email",
+		type: "email",
+		component: "PapaMail",
+		validation: [{
+			type: "function",
+			value: function() {
+				return true;
+			}
+		}]
+	}
+};
+
+const entityMock = {
+  contact: {
+    firstName: {
+      domain: "DO_TEXT",
+      required: false
+    },
+    lastName: {
+      domain: "DO_TEXT",
+      required: true
+    },
+    age: {
+      "domain": "DO_NUMBER",
+      "required": false
+    },
+    email: {
+      domain: "DO_EMAIL",
+      required: false
+    }
+  }
+};
+
+// initialize the entity conf.
+definition.domain.container.setAll(DOMAIN);
+definition.entity.container.setEntityConfiguration(entityMock);
+
+describe('The definition behaviour', () => {
+
+    describe('when called with a wrong definition path', () => {
+        it('shoud throw an error when the param is undefined',  () => {
+            expect(() => DefinitionBehaviour()).to.throw(Error);
+        });
+        it('shoud throw an error when when the param is null',  () => {
+            expect(() => DefinitionBehaviour(null)).to.throw(Error);
+        });
+        it('shoud throw an error when the param is an object',  () => {
+            expect(() => DefinitionBehaviour({})).to.throw(Error);
+        });
+        it('shoud throw a number when the param is an object',  () => {
+            expect(() => DefinitionBehaviour(1)).to.throw(Error);
+        });
+        it('shoud not throw an error when the param is a string and not the definition map',  () => {
+            expect(() => DefinitionBehaviour('test')).to.throw(Error);
+        });
+        it('shoud not throw an error when the param is a string and in the definition map',  () => {
+            expect(() => DefinitionBehaviour('contact')).to.not.throw(Error);
+        });
+        /*before(() => {
+            @DefinitionBehaviour('contact')
+            class TestComponent extends React.Component {
+                render() {
+                    return (
+                        <div ref='myRef'>
+                        {this.props.test}
+                        </div>
+                    );
+                }
+            }
+            TestUtils.renderIntoDocument(<TestComponent test='hello'/>);
+        });
+        it('should not bind mdl JS', () => {
+            expect(mdlSpy.upgradeElement).not.to.be.called;
+        });*/
+    });
+
+
+});

--- a/src/behaviours/definition/__tests__/definition-behaviour-test.js
+++ b/src/behaviours/definition/__tests__/definition-behaviour-test.js
@@ -104,6 +104,7 @@ describe('The definition behaviour', () => {
             const renderedComponent = TestUtils.renderIntoDocument(<CompWithDef test='hello'/>);
 			expect(renderedComponent.refs.wrappedComponent.props.definition)
 				  .to.have.property('firstName');
+				// console.log('firstName %j', renderedComponent.refs.wrappedComponent.props.definition.firstName)
         });
         /*before(() => {
             @DefinitionBehaviour('contact')

--- a/src/behaviours/definition/__tests__/definition-behaviour-test.js
+++ b/src/behaviours/definition/__tests__/definition-behaviour-test.js
@@ -106,22 +106,6 @@ describe('The definition behaviour', () => {
 				  .to.have.property('firstName');
 				// console.log('firstName %j', renderedComponent.refs.wrappedComponent.props.definition.firstName)
         });
-        /*before(() => {
-            @DefinitionBehaviour('contact')
-            class TestComponent extends React.Component {
-                render() {
-                    return (
-                        <div ref='myRef'>
-                        {this.props.test}
-                        </div>
-                    );
-                }
-            }
-            TestUtils.renderIntoDocument(<TestComponent test='hello'/>);
-        });
-        it('should not bind mdl JS', () => {
-            expect(mdlSpy.upgradeElement).not.to.be.called;
-        });*/
     });
 
 

--- a/src/behaviours/definition/__tests__/definition-behaviour-test.js
+++ b/src/behaviours/definition/__tests__/definition-behaviour-test.js
@@ -22,6 +22,9 @@ const DOMAIN = {
 				return true;
 			}
 		}]
+	},
+	DO_NUMBER:{
+		type: 'number'
 	}
 };
 
@@ -71,25 +74,20 @@ describe('The definition behaviour', () => {
         it('shoud not throw an error when the param is a string and in the definition map',  () => {
             expect(() => DefinitionBehaviour('contact')).to.not.throw(Error);
         });
-        it.only('Annotation test', () => {
+        it('Annotation test', () => {
 
-
-            class TestComponent extends React.Component {
+		    class TestComponent extends React.Component {
                 render() {
-                    return (
+					return (
                         <div ref='myRef'>
-                            {this.props.test}
+                            {JSON.stringify(this.props)}
                         </div>
                     );
                 }
             }
-
 			const CompWithDef = DefinitionBehaviour('contact')(TestComponent);
-			console.log('CompWithDef')
-			console.log(CompWithDef)
             const renderedComponent = TestUtils.renderIntoDocument(<CompWithDef test='hello'/>);
-            console.log(renderedComponent);
-            expect(renderedComponent.props).to.have.property('contact')
+			expect(renderedComponent.refs.wrappedComponent.props).to.have.property('definition')
 
         })
         /*before(() => {

--- a/src/behaviours/definition/__tests__/entity-conf-mock.json
+++ b/src/behaviours/definition/__tests__/entity-conf-mock.json
@@ -1,0 +1,20 @@
+{
+  "contact": {
+    "firstName": {
+      "domain": "DO_TEXT",
+      "required": false
+    },
+    "lastName": {
+      "domain": "DO_TEXT",
+      "required": true
+    },
+    "age": {
+      "domain": "DO_NUMBER",
+      "required": false
+    },
+    "email": {
+      "domain": "DO_EMAIL",
+      "required": false
+    }
+  }
+}

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -28,10 +28,10 @@ export default function definitionBehaviout(definitionPath, additionalDefinition
 
     // annotation
     // The wrapped component should have a props containing the definition object.
-    return function wrapWithDefinition(ComponentToWrap){
+    return function wrapWithDefinition(ComponentToWrap) {
 
         // Save the display name for later
-        const displayName = DecoratedComponent.displayName || 'Component';
+        const displayName = ComponentToWrap.displayName || 'Component';
 
         // Wrapped component
         function DefinitionWrappedComponent(props) {
@@ -39,8 +39,8 @@ export default function definitionBehaviout(definitionPath, additionalDefinition
         }
 
         DefinitionWrappedComponent.displayName =  `${displayName}WithDefinition`;
-
-        return DefinitionWrappedComponent
+        console.log(DefinitionWrappedComponent);
+        return DefinitionWrappedComponent;
     }
 }
 

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react';
-import {getEntityInformations} from 'focus-core/definition/entity/builder';
+import {definition} from 'focus-core';
+const getEntityInformations =  definition.entity.builder.getEntityInformations;
 import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
 
 /**
@@ -14,7 +15,7 @@ import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
 export default function definitionBehaviout(definitionPath, additionalDefinition){
 
     // Arguments validation
-    if(isUndefined(definitionPath) || isNull(definitionPath)|| !isString(definitionPath) || !isArray(definitionPath)){
+    if(isUndefined(definitionPath) || isNull(definitionPath)|| (!isString(definitionPath) && !isArray(definitionPath))){
         throw new Error('the definition path should be givent in order to to know the domain of your entity property.');
     }
     if(!isUndefined(additionalDefinition) && !isNull(additionalDefinition) && !isObject(additionalDefinition)){

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react';
+import React, {Component, PropTypes} from 'react';
 import {definition} from 'focus-core';
 const getEntityInformations =  definition.entity.builder.getEntityInformations;
 import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
@@ -34,12 +34,17 @@ export default function definitionBehaviout(definitionPath, additionalDefinition
         const displayName = ComponentToWrap.displayName || 'Component';
 
         // Wrapped component
-        function DefinitionWrappedComponent(props) {
-            return <ComponentToWrap definition={definition} {...props}/>;
+//        function DefinitionWrappedComponent(props) {
+//            return <ComponentToWrap definition={definition} {...props}/>;
+//        }
+        class DefinitionWrappedComponent extends Component {
+            render(){
+                return <ComponentToWrap ref='wrappedComponent' definition={definition} {...this.props}/>;
+            }
         }
 
         DefinitionWrappedComponent.displayName =  `${displayName}WithDefinition`;
-        console.log(DefinitionWrappedComponent);
+        //console.log(DefinitionWrappedComponent);
         return DefinitionWrappedComponent;
     }
 }

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -19,7 +19,7 @@ const getEntityInformations =  definition.entity.builder.getEntityInformations;
  * @return {function} - A function to commect a component to a definition.
  * @example please read the end of the file.
  */
-export default function definitionBehaviout(definitionPath, additionalDefinition){
+export default function definitionBehaviour(definitionPath, additionalDefinition){
 
     // Arguments validation
     if(isUndefined(definitionPath) || isNull(definitionPath)|| (!isString(definitionPath) && !isArray(definitionPath))){
@@ -35,7 +35,7 @@ export default function definitionBehaviout(definitionPath, additionalDefinition
 
     // annotation
     // The wrapped component should have a props containing the definition object.
-    return function wrapWithDefinition(ComponentToWrap) {
+    return function wrapComponentWithDefinition(ComponentToWrap) {
 
         // Save the display name for later
         const displayName = ComponentToWrap.displayName || 'Component';

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -1,7 +1,13 @@
+//Dependencies
 import React, {Component, PropTypes} from 'react';
+import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
+
+// Import from focus-core
+// We need to investigate why import {getEntityInformations} from 'focus-core/entity/builder' didn't work, maybe an ES2015 related issue with babel.
+// Maybe because the node modules reads from the builded lib  instead of src.
 import {definition} from 'focus-core';
 const getEntityInformations =  definition.entity.builder.getEntityInformations;
-import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
+
 
 /**
  * This function is a behaviour. It aims to comment a component to a definition.
@@ -11,6 +17,7 @@ import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
  * @param  {string | array} definitionPath - A string or an array of the definition path to the configuration.
  * @param  {object} additionalDefinition - If you need to override a definition for a specific component, you can use this object.
  * @return {function} - A function to commect a component to a definition.
+ * @example please read the end of the file.
  */
 export default function definitionBehaviout(definitionPath, additionalDefinition){
 
@@ -33,18 +40,31 @@ export default function definitionBehaviout(definitionPath, additionalDefinition
         // Save the display name for later
         const displayName = ComponentToWrap.displayName || 'Component';
 
-        // Wrapped component
-//        function DefinitionWrappedComponent(props) {
-//            return <ComponentToWrap definition={definition} {...props}/>;
-//        }
+        // TODO: @reviewer
+        // It could have been nice to have a pure function for this.
+        // Except for the tests, do we need a React.Component class and a ref.
+        // I think it is safer to have it instead of a pure function.
+        // Maybe we should have a look on `ownPropertyDescriptor` instead of wrapping class aruoud component for this case.
+        // But having everything as props is really clean.
+
+        // # Wrapped component
+        //        function DefinitionWrappedComponent(props) {
+        //            return <ComponentToWrap definition={definition} {...props}/>;
+        //        }
+
+        /**
+         * This class stands for the wrapped component with its props plus the definition object as props.
+         * It has a reference to the wrapped component in `this.refs.wrappedComponent`
+         */
         class DefinitionWrappedComponent extends Component {
             render(){
                 return <ComponentToWrap ref='wrappedComponent' definition={definition} {...this.props}/>;
             }
         }
 
+        // Add with definition to the name of the component.
         DefinitionWrappedComponent.displayName =  `${displayName}WithDefinition`;
-        //console.log(DefinitionWrappedComponent);
+
         return DefinitionWrappedComponent;
     }
 }
@@ -59,7 +79,7 @@ class MyComponent{
 
     }
 }
-
+// The annotation is just a function, you compose your component with a definition builder.
 const MyComponentWithDefinition = definition('path.to.my.awesome.entity')(MyComponent);
 
  // ES7

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -1,0 +1,68 @@
+import React, {PropTypes} from 'react';
+import {getEntityInformations} from 'focus-core/definition/entity/builder';
+import {isNull, isUndefined, isArray, isString} from 'lodash/lang';
+
+/**
+ * This function is a behaviour. It aims to comment a component to a definition.
+ *  - A definition is related to the data model
+ *  - Each field of the domain have a definition which contains its domain and the fact that it is required ot not.
+ *  - The definitions of your application should have been set using `focus-core/definition/entity/container/setEntityConfiguration`
+ * @param  {string | array} definitionPath - A string or an array of the definition path to the configuration.
+ * @param  {object} additionalDefinition - If you need to override a definition for a specific component, you can use this object.
+ * @return {function} - A function to commect a component to a definition.
+ */
+export default function definitionBehaviout(definitionPath, additionalDefinition){
+
+    // Arguments validation
+    if(isUndefined(definitionPath) || isNull(definitionPath)|| !isString(definitionPath) || !isArray(definitionPath)){
+        throw new Error('the definition path should be givent in order to to know the domain of your entity property.');
+    }
+    if(!isUndefined(additionalDefinition) && !isNull(additionalDefinition) && !isObject(additionalDefinition)){
+        throw new Error('The additional definition if is defined should be an object');
+    }
+
+    // Definition Construction
+    const definitionConf = isArray(definitionPath) ? definitionPath : [definitionPath];
+    const definition = definitionConf.reduce((valeurPrecedente, valeurCourante) => ({...valeurPrecedente, ...getEntityInformations(definitionPath, additionalDefinition)}), {});
+
+    // annotation
+    return function wrapWithDefinition(ComponentToWrap){
+
+        // Save the display name for later
+        const displayName = DecoratedComponent.displayName || 'Component';
+
+        // Wrapped component
+        function DefinitionWrappedComponent(props) {
+            return <ComponentToWrap definition={definition} {...props}/>;
+        }
+
+        DefinitionWrappedComponent.displayName =  `${displayName}WithDefinition`;
+
+        return DefinitionWrappedComponent
+    }
+}
+
+/*
+ Example
+// ES6
+
+class MyComponent{
+    render(){
+      return <div>{JSON.stringify(this.props)}</div>;
+
+    }
+}
+
+const MyComponentWithDefinition = definition('path.to.my.awesome.entity')(MyComponent);
+
+ // ES7
+
+@definition('path.to.my.awesome.entity')
+class MyComponent{
+    render(){
+      return <div>{JSON.stringify(this.props)}</div>;
+
+    }
+}
+
+*/

--- a/src/behaviours/definition/index.js
+++ b/src/behaviours/definition/index.js
@@ -26,6 +26,7 @@ export default function definitionBehaviout(definitionPath, additionalDefinition
     const definition = definitionConf.reduce((valeurPrecedente, valeurCourante) => ({...valeurPrecedente, ...getEntityInformations(definitionPath, additionalDefinition)}), {});
 
     // annotation
+    // The wrapped component should have a props containing the definition object.
     return function wrapWithDefinition(ComponentToWrap){
 
         // Save the display name for later


### PR DESCRIPTION
# Defintion behaviour

## Description

Creates a **behaviour** for the `definition` related element of a component.

- `@definition('myentity.definition')`
- A definition is related to the data model
- Each field of the domain have a definition which contains its domain and the fact that it is required ot not.
- The definitions of your application should have been set using `focus-core/definition/entity/container/setEntityConfiguration`
- * @param  {string | array} definitionPath - A string or an array of the definition path to the configuration.
-  * @param  {object} additionalDefinition - If you need to override a definition for a specific component, you can use this object.
-  * @return {function} - A function to commect a component to a definition.

## Example code

```jsx
 Example
// ES6

class MyComponent{
    render(){
      return <div>{JSON.stringify(this.props)}</div>;

    }
}
// The annotation is just a function, you compose your component with a definition builder.
const MyComponentWithDefinition = definition('path.to.my.awesome.entity')(MyComponent);

 // ES7

@definition('path.to.my.awesome.entity')
class MyComponent{
    render(){
      return <div>{JSON.stringify(this.props)}</div>;

    }
}
```

Part of the new component / form spec #708