### PR TITLE
[scrollspy-menu] correction of scroll position when a menu element is clicked

### DIFF
--- a/src/behaviours/scroll/index.js
+++ b/src/behaviours/scroll/index.js
@@ -7,16 +7,20 @@ const Scroll = Component => class ScrollComponent extends Component {
 
     /**
     * Get the scroll position from the top of the screen.
+    *
+    * https://developer.mozilla.org/fr/docs/Web/API/Element/getBoundingClientRect
+    *
     * @param {object} domNode domNoe to get the position from
     * @returns {int} - The position in pixel from the top of the scroll container.
     */
     scrollPosition(domNode) {
+        const y = window.pageYOffset || document.documentElement.scrollTop;
+        const x = window.pageXOffset || document.documentElement.scrollLeft;
         if(isUndefined(domNode)) {
-            const y = window.pageYOffset || document.documentElement.scrollTop;
-            const x = window.pageXOffset || document.documentElement.scrollLeft;
             return { top: y, left: x };
         }
-        return { top: domNode.scrollTop, left: domNode.scrollLeft };
+        const nodeRect = domNode.getBoundingClientRect();
+        return { left: nodeRect.left + x, top: nodeRect.top + y };
     }
 
 


### PR DESCRIPTION
# Previous behaviour

 If header is in full size, clicking on an item in the left menu doesn't display the right bloc(the scroll is too low). 
This error doesn't exist when the header is in the "scroll state".

![error left menu](https://cloud.githubusercontent.com/assets/1950825/11472753/09e8212c-976f-11e5-9bf1-e7809ca86ad0.gif)

# Fix

Click on a menu element scroll the page on the right element.

> Fixes #740 
