### PR TITLE
[search bar] No spinner on search action

### DIFF
--- a/src/search/search-bar/index.js
+++ b/src/search/search-bar/index.js
@@ -70,6 +70,7 @@ const SearchBar = {
     componentWillMount() {
         this.props.store.addQueryChangeListener(this._onQueryChangeFromStore);
         this.props.store.addScopeChangeListener(this._onScopeChangeFromStore);
+        this.props.store.addResultsChangeListener(this._onResultsChangeFromStore);
     },
     /**
      * Component did unmount handler
@@ -77,6 +78,7 @@ const SearchBar = {
     componentWillUnmount() {
         this.props.store.removeQueryChangeListener(this._onQueryChangeFromStore);
         this.props.store.removeScopeChangeListener(this._onScopeChangeFromStore);
+        this.props.store.removeResultsChangeListener(this._onResultsChangeFromStore);
     },
     /**
      * Query changed in store event handler
@@ -94,6 +96,10 @@ const SearchBar = {
             scope: this.props.store.getScope()
         });
     },
+
+    _onResultsChangeFromStore() {
+        this.setState({loading: false});
+    },
     /**
      * Broadcast query change
      */
@@ -101,6 +107,9 @@ const SearchBar = {
         actionWrapper(() => {
             this.props.action.updateProperties({
                 query: this.refs.query.getValue()
+            });
+            this.setState({
+                loading: true
             });
         })();
     },
@@ -161,8 +170,8 @@ const SearchBar = {
     * @return {HTML} - The rendered component
     */
     render() {
-        const {loading, hasScopes, placeholder, scopes} = this.props;
-        const {query, scope} = this.state;
+        const {hasScopes, placeholder, scopes} = this.props;
+        const {loading, query, scope} = this.state;
         return (
             <div data-focus='search-bar'>
                 {hasScopes &&
@@ -171,7 +180,7 @@ const SearchBar = {
                 <div data-focus='search-bar-input'>
                     <Input onChange={this._onInputChange} onKeyPress={this._handleInputKeyPress} placeholder={this.i18n(placeholder)} ref='query' value={query}/>
                     {loading &&
-                        <div className={`sb-spinner three-quarters-loader`} />
+                        <div className='three-quarters-loader' data-role='spinner'></div>
                     }
                 </div>
             </div>

--- a/src/search/search-bar/style/search-bar.scss
+++ b/src/search/search-bar/style/search-bar.scss
@@ -33,5 +33,16 @@ $search-bar-border-bottom:1px solid rgba(0, 0, 0, 0.117647);
                 font-size: $search-bar-font-size;
             }
         }
+
+        [data-role="spinner"] {
+            position: relative;
+            right: 62px;
+            top: 5px;
+            border: 2px solid #38e;
+            border-right-color: transparent;
+            border-radius: 16px;
+            width: 25px;
+            height: 25px;
+        }
     }
 }


### PR DESCRIPTION
## No spinner on search action

### Description

When the search action is triggered, no spinner is displayed.

![image](https://cloud.githubusercontent.com/assets/4435377/11785016/d0a5d302-a27f-11e5-91a1-f405958b51dc.png)

### Patch

Add a spinner that will appear on the action call, and disappear with the server response.

![image](https://cloud.githubusercontent.com/assets/4435377/11785055/049bf52e-a280-11e5-9e6d-bf37000a8bde.png)

Fixes #623 