### PR TITLE
Fix #624 secondary actions

### DIFF
--- a/src/components/icon-dropdown/index.js
+++ b/src/components/icon-dropdown/index.js
@@ -1,0 +1,47 @@
+import React, {Component, PropTypes} from 'react';
+import {component as Button} from '../../common/button/action';
+import IconMenu from 'material-ui/lib/menus/icon-menu';
+
+class Dropdown extends Component {
+    static propTypes = {
+        openDirection: PropTypes.oneOf(['bottom-left', 'bottom-right', 'top-left', 'top-right']),
+    }
+
+    static defaultProps = {
+        openDirection: 'bottom-left',
+        iconProps: {
+            name: 'more_vert',
+            iconLibrary: 'material'
+        },
+        shape: 'fab',
+        operationList: []
+    }
+
+    render() {
+        const {iconProps: {name, iconLibrary}, operationList, shape} = this.props;
+        const buttonElement = (
+            <Button
+                shape={shape}
+                icon={name}
+                iconLibrary={iconLibrary}
+                handleOnClick={event => {
+                    this.refs.iconMenu.open('iconTap', event);
+                }}
+                />
+        );
+        return (
+            <div data-focus='icon-dropdown'>
+                <IconMenu
+                    iconButtonElement={buttonElement}
+                    ref='iconMenu'
+                    >
+                    <div data-focus='dropdown-menu'>
+                        {operationList.map(({label, action}, idx) => (<div key={idx} data-role='dropdown-item' onClick={action}>{label}</div>))}
+                    </div>
+                </IconMenu>
+            </div>
+        )
+    }
+}
+
+export default Dropdown;

--- a/src/components/icon-dropdown/style.scss
+++ b/src/components/icon-dropdown/style.scss
@@ -1,0 +1,20 @@
+[data-focus='icon-dropdown'] {
+    [data-focus='dropdown-menu'] {
+        [data-role='dropdown-item'] {
+            padding: 10px;
+            cursor: pointer;
+            white-space: nowrap;
+            width: 100%;
+            text-align: left;
+
+            &:hover {
+                background-color: #EEE;
+            }
+        }
+    }
+
+    // A bit hackish but necessary to override material-ui's inline style
+    div > span > div > div > div {
+        padding: 0 !important;
+    }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ import menuLeft from './menu';
 import panel from './panel';
 import scrollspyContainer from './scrollspy-container';
 import Confirm from './confirm';
+import IconDropdown from './icon-dropdown';
 
 export default {
     HeaderActions: headerActions,
@@ -21,5 +22,6 @@ export default {
     Layout: layout,
     MenuLeft: menuLeft,
     Panel: panel,
-    ScrollspyContainer: scrollspyContainer
+    ScrollspyContainer: scrollspyContainer,
+    IconDropdown
 }

--- a/src/components/layout/header-actions.js
+++ b/src/components/layout/header-actions.js
@@ -1,20 +1,19 @@
 import React, {Component} from 'react';
 import Focus from 'focus-core';
-import Button from '../../common/button/action';
-import Dropdown from '../../common/select-action';
+import {component as Button} from '../../common/button/action';
+import Dropdown from '../../components/icon-dropdown';
 
 // variables
 const applicationStore = Focus.application.builtInStore;
 
-// Components
-const ButtonComponent = Button.component;
-const DropdownComponent = Dropdown.component;
 
 // component default props.
 //const defaultProps = {};
 
 // component props definition.
 //const propTypes = {};
+
+const Test = ({clickHandler}) => (<div onClick={clickHandler}>Ouvrir</div>);
 
 /**
 * HeaderActions component.
@@ -59,10 +58,10 @@ class HeaderActions extends Component {
                 {actions.primary.map((primary, index) => {
                     const {action, className, icon, iconLibrary, label, ...otherProps} = primary;
                     return (
-                        <ButtonComponent key={`header-action-${index}`} className={className} handleOnClick={action} icon={icon} iconLibrary={iconLibrary} label={label} shape='fab' type='button' {...otherProps}/>
+                        <Button key={`header-action-${index}`} className={className} handleOnClick={action} icon={icon} iconLibrary={iconLibrary} label={label} shape='fab' type='button' {...otherProps}/>
                     );
                 })}
-                <DropdownComponent iconProps={{name: 'more_vert'}} operationList={actions.secondary} shape='fab'/>
+                {actions.secondary.length > 0 && <Dropdown operationList={actions.secondary}/>}
             </div>
         );
     }

--- a/src/style/index.js
+++ b/src/style/index.js
@@ -44,6 +44,7 @@ import '../components/menu/style/menu.scss';
 import '../components/panel/style/panel.scss'
 import '../components/scrollspy-container/style/scrollspy-container.scss';
 import '../components/scrollspy-container/style/sticky-menu.scss';
+import '../components/icon-dropdown/style.scss';
 import '../list/action-contextual/style/contextual-ation.scss';
 import '../list/selection/style/list.scss';
 import '../list/summary/style/list-summary.scss';


### PR DESCRIPTION
## Secondary actions are not reliably set

### Description

When using the secondary actions in the header, getting asynchronously the action list breaks the dropdown menu.

### Patch

Refactored the dropdown component, using Material UI's base.

![image](https://cloud.githubusercontent.com/assets/4435377/11874169/9e977170-a4de-11e5-9ec0-efb5405042a0.png)

Fixes #624 