### PR TITLE
[Search] scopes are not translated

### DIFF
--- a/src/search/search-bar/scope.js
+++ b/src/search/search-bar/scope.js
@@ -107,7 +107,7 @@ const scopeMixin = {
                             {scope.code &&
                                 <Icon name={code} {...otherScopeProps}/>
                             }
-                            <span>{label}</span>
+                            <span>{this.i18n(label)}</span>
                         </li>
                     );
                 })}
@@ -131,7 +131,7 @@ const scopeMixin = {
             <div data-focus='search-bar-scope'>
                 <button className='mdl-button mdl-js-button' id={scopesId} data-scope={code}>
                     <Icon name={code} {...otherScopeProps}/>
-                    <span>{label}</span>
+                    <span>{this.i18n(label)}</span>
                 </button>
                 {this._renderScopeList()}
             </div>


### PR DESCRIPTION
# issue

Scope labels were not translated which did not allowed multi-linguism.
![image](https://cloud.githubusercontent.com/assets/5349745/11901957/d12f8ba6-a5ae-11e5-8b31-4e9cb28c550e.png)

# correction

Scope labels are now translated.
![image](https://cloud.githubusercontent.com/assets/5349745/11901949/bfae6bea-a5ae-11e5-80ee-6473486fa452.png)
