### PR TITLE
Header size management refactor.

### DIFF
--- a/src/application/confirmation-popin/style/confirmation-popin.scss
+++ b/src/application/confirmation-popin/style/confirmation-popin.scss
@@ -1,7 +1,7 @@
 [data-focus='confirmation-popin'] {
   [data-focus='button-stack'] {
     text-align: center;
-    position: fixed;
+    position: absolute;
     bottom: 0;
     width: 100%;
 

--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -99,8 +99,8 @@ class HeaderScrolling extends Component {
 
         if (this.state.isDeployed) {
             let content = document.querySelector('header');
-            deployThreshold = content ? content.offsetHeight - 60 : 1000;
-            placeholderHeight = content ? content.clientHeight - 125 : 1000;
+            deployThreshold = content ? content.clientHeight - 60 : 1000;
+            placeholderHeight = content ? content.clientHeight : 1000;
             this.setState({deployThreshold, placeholderHeight});
         }
 
@@ -114,12 +114,12 @@ class HeaderScrolling extends Component {
 
     /** @inheriteddoc */
     render() {
-        const {mode, route, isDeployed, placeholderHeight} = this.state;
+        const {mode, route, isDeployed, canDeploy, placeholderHeight} = this.state;
         const {children} = this.props;
         return (
             <header data-focus='header-scrolling' data-mode={mode} data-route={route} data-deployed={isDeployed}>
                 {children}
-                {!isDeployed ? <div style={{height: placeholderHeight, width: '100%'}} /> : ''}
+                {!isDeployed ? <div style={{height: canDeploy ? placeholderHeight : 60, width: '100%'}} /> : ''}
             </header>
         );
     }

--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -70,9 +70,9 @@ class HeaderScrolling extends Component {
         this.scrollTargetNode.removeEventListener('resize', this.handleScroll);
     }
 
-   /**
-    * Notify other elements that the header has added/removed the cartridge.
-    */
+    /**
+     * Notify other elements that the header has added/removed the cartridge.
+     */
     _notifySizeChange = () => {
         const {notifySizeChange} = this.props;
         const {isDeployed} = this.state;
@@ -82,14 +82,14 @@ class HeaderScrolling extends Component {
     }
 
     /**
-    * Handle the scroll event in order to show/hide the cartridge.
-    * @param {object} event [description]
-    */
+     * Handle the scroll event in order to show/hide the cartridge.
+     * @param {object} event [description]
+     */
     handleScroll = (event) => {
         let {deployThreshold, placeholderHeight} = this.state;
 
         if (this.state.isDeployed) {
-            const content = document.querySelector('header');
+            const content = this.refs ? this.refs.header : undefined;
             deployThreshold = content ? content.clientHeight - 60 : 1000; // 1000 is arbitrary, but a value high enough is required by default.
             placeholderHeight = content ? content.clientHeight : 1000;
             this.setState({deployThreshold, placeholderHeight});
@@ -108,7 +108,7 @@ class HeaderScrolling extends Component {
         const {isDeployed, placeholderHeight} = this.state;
         const {children, canDeploy, mode, route} = this.props;
         return (
-            <header data-focus='header-scrolling' data-mode={mode} data-route={route} data-deployed={isDeployed}>
+            <header ref='header' data-focus='header-scrolling' data-mode={mode} data-route={route} data-deployed={isDeployed}>
                 {children}
                 {!isDeployed ? <div style={{height: canDeploy ? placeholderHeight : 60, width: '100%'}} /> : ''}
             </header>

--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -26,7 +26,7 @@ const propTypes = {
 class HeaderScrolling extends Component {
     constructor(props) {
         super(props);
-        let storeState = this._getStateFromStore()
+        const storeState = this._getStateFromStore()
         storeState.canDeploy = props.canDeploy;
         storeState.isDeployed = props.canDeploy;
         this.state = storeState;
@@ -97,14 +97,14 @@ class HeaderScrolling extends Component {
         let {deployThreshold, placeholderHeight} = this.state;
 
         if (this.state.isDeployed) {
-            let content = document.querySelector('header');
-            deployThreshold = content ? content.clientHeight - 60 : 1000;
+            const content = document.querySelector('header');
+            deployThreshold = content ? content.clientHeight - 60 : 1000; // 1000 is arbitrary, but a value high enough is required by default.
             placeholderHeight = content ? content.clientHeight : 1000;
             this.setState({deployThreshold, placeholderHeight});
         }
 
         const {top} = this.scrollPosition();
-        let isDeployed = this.state.canDeploy ? top < deployThreshold : false;
+        const isDeployed = this.state.canDeploy ? top < deployThreshold : false;
 
         if (isDeployed !== this.state.isDeployed) {
             this.setState({isDeployed}, this._notifySizeChange);

--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -1,20 +1,18 @@
 import React, {Component, PropTypes} from 'react';
 import Focus from 'focus-core';
-import ReactDom from 'react-dom';
-import {pluck, sortBy} from 'lodash/collection';
 import Scroll from '../../behaviours/scroll';
 
-// variables
+// Variables
 const applicationStore = Focus.application.builtInStore;
 
-// component default props.
+// Component default props.
 const defaultProps = {
     canDeploy: true, // Determines if the header can be deployed (revealing the cartridge component) or not.
     notifySizeChange: undefined, // A handler to notify other elements that the header has added/removed the cartridge.
     scrollTargetSelector: undefined // Selector for the domNode on which the scroll is attached.
 };
 
-// component props definition.
+// Component props definition.
 const propTypes = {
     canDeploy: PropTypes.bool,
     notifySizeChange: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -51,8 +49,8 @@ class HeaderScrolling extends Component {
     }
 
     _handleChangeApplicationStatus = () => {
-        this.handleScroll();
         this.setState(this._getStateFromStore());
+        this.handleScroll();
     }
 
     _getStateFromStore = () => {
@@ -66,7 +64,8 @@ class HeaderScrolling extends Component {
         return {
             mode: mode,
             route: applicationStore.getRoute(),
-            canDeploy: applicationStore.getCanDeploy()
+            canDeploy: applicationStore.getCanDeploy(),
+            isDeployed: applicationStore.getCanDeploy()
         };
     }
 

--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -10,7 +10,6 @@ const applicationStore = Focus.application.builtInStore;
 // component default props.
 const defaultProps = {
     canDeploy: true, // Determines if the header can be deployed (revealing the cartridge component) or not.
-    deployThreshold: 150, // The y-scrolling threshold that shows/hides the cartridge.
     notifySizeChange: undefined, // A handler to notify other elements that the header has added/removed the cartridge.
     scrollTargetSelector: undefined // Selector for the domNode on which the scroll is attached.
 };
@@ -18,7 +17,6 @@ const defaultProps = {
 // component props definition.
 const propTypes = {
     canDeploy: PropTypes.bool,
-    deployThreshold: PropTypes.number,
     notifySizeChange: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     scrollTargetSelector: PropTypes.string
 };
@@ -97,8 +95,17 @@ class HeaderScrolling extends Component {
     * @param {object} event [description]
     */
     handleScroll = (event) => {
+        let {deployThreshold, placeholderHeight} = this.state;
+
+        if (this.state.isDeployed) {
+            let content = document.querySelector('header');
+            deployThreshold = content ? content.offsetHeight - 60 : 1000;
+            placeholderHeight = content ? content.clientHeight - 125 : 1000;
+            this.setState({deployThreshold, placeholderHeight});
+        }
+
         const {top} = this.scrollPosition();
-        let isDeployed = this.state.canDeploy ? top < this.props.deployThreshold : false;
+        let isDeployed = this.state.canDeploy ? top < deployThreshold : false;
 
         if (isDeployed !== this.state.isDeployed) {
             this.setState({isDeployed}, this._notifySizeChange);
@@ -107,11 +114,12 @@ class HeaderScrolling extends Component {
 
     /** @inheriteddoc */
     render() {
-        const {mode, route, isDeployed} = this.state;
+        const {mode, route, isDeployed, placeholderHeight} = this.state;
         const {children} = this.props;
         return (
             <header data-focus='header-scrolling' data-mode={mode} data-route={route} data-deployed={isDeployed}>
                 {children}
+                {!isDeployed ? <div style={{height: placeholderHeight, width: '100%'}} /> : ''}
             </header>
         );
     }

--- a/src/components/layout/style/header-scrolling.scss
+++ b/src/components/layout/style/header-scrolling.scss
@@ -46,7 +46,7 @@ to { height: auto; }
     }
 
     //When the size is medium, the summary-bar is not visible.
-    &[data-size="medium"] {
+    &[data-deployed="true"] {
         div[data-focus="header-top-row"] {
             div[data-focus="header-top-row-middle"] {
                 display: none;
@@ -60,7 +60,7 @@ to { height: auto; }
     }
 
     //When the size is min  don't show the cartridge
-    &[data-size="small"] {
+    &[data-deployed="false"] {
         height: $header-top-row-height;
         overflow-y: hidden;
         [data-focus="header-top-row"] {
@@ -83,7 +83,7 @@ to { height: auto; }
 [data-focus="layout"] {
     &[data-menu="left"] {
         [data-focus="header-scrolling"] {
-            &[data-size="small"] {
+            &[data-deployed="false"] {
                 [data-focus="header-top-row"] {
                     & > div {
                         margin-left: $header-top-row-height;

--- a/src/components/layout/style/header-scrolling.scss
+++ b/src/components/layout/style/header-scrolling.scss
@@ -45,8 +45,10 @@ to { height: auto; }
         display: inline;
     }
 
-    //When the size is medium, the summary-bar is not visible.
+    // When the header is deployed, don't show the summary.
     &[data-deployed="true"] {
+        z-index: $header-top-row-zindex;
+
         div[data-focus="header-top-row"] {
             div[data-focus="header-top-row-middle"] {
                 display: none;
@@ -59,15 +61,21 @@ to { height: auto; }
         }
     }
 
-    //When the size is min  don't show the cartridge
+    // When the header is collasped, don't show the cartridge.
     &[data-deployed="false"] {
+        z-index: inherit;
         overflow-y: hidden;
+
         [data-focus="header-top-row"] {
             @include shadow();
             position: fixed;
             top: 0;
             left: 0;
             width: 100%;
+        }
+
+        [data-focus="header-content"] {
+            display: none;
         }
 
         [data-focus="header-actions"] {

--- a/src/components/layout/style/header-scrolling.scss
+++ b/src/components/layout/style/header-scrolling.scss
@@ -61,7 +61,6 @@ to { height: auto; }
 
     //When the size is min  don't show the cartridge
     &[data-deployed="false"] {
-        height: $header-top-row-height;
         overflow-y: hidden;
         [data-focus="header-top-row"] {
             @include shadow();
@@ -77,6 +76,8 @@ to { height: auto; }
             right: 0;
             z-index: $header-top-row-zindex;
         }
+
+        box-shadow: none;
     }
 }
 

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -26,9 +26,9 @@ export default {
             `);
         }
 
-        let cartridgeConf = this.cartridgeConfiguration();
+        const cartridgeConf = this.cartridgeConfiguration();
 
-        let data = {
+        const data = {
             cartridgeComponent: cartridgeConf.cartridge || {component: Empty},
             summaryComponent: cartridgeConf.summary || {component: Empty},
             actions: cartridgeConf.actions || {primary: [], secondary: []},

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -33,7 +33,7 @@ export default {
             summaryComponent: cartridgeConf.summary || {component: Empty},
             actions: cartridgeConf.actions || {primary: [], secondary: []},
             barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
-            isDeployed: cartridgeConf.isDeployed || true
+            canDeploy: cartridgeConf.canDeploy || true
         };
 
         if (cartridgeConf.barRight) {

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -1,4 +1,4 @@
-import {isFunction} from 'lodash/lang';
+import {isFunction, isUndefined} from 'lodash/lang';
 import {dispatcher} from 'focus-core';
 import {component as Empty} from '../../common/empty';
 
@@ -33,7 +33,7 @@ export default {
             summaryComponent: cartridgeConf.summary || {component: Empty},
             actions: cartridgeConf.actions || {primary: [], secondary: []},
             barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
-            canDeploy: _.isUndefined(cartridgeConf.canDeploy) ? true : cartridgeConf.canDeploy
+            canDeploy: isUndefined(cartridgeConf.canDeploy) ? true : cartridgeConf.canDeploy
         };
 
         if (cartridgeConf.barRight) {

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -33,7 +33,7 @@ export default {
             summaryComponent: cartridgeConf.summary || {component: Empty},
             actions: cartridgeConf.actions || {primary: [], secondary: []},
             barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
-            headerSize: cartridgeConf.headerSize || 'medium'
+            isDeployed: cartridgeConf.isDeployed || true
         };
 
         if (cartridgeConf.barRight) {

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -28,17 +28,19 @@ export default {
 
         let cartridgeConf = this.cartridgeConfiguration();
 
-        dispatcher.handleViewAction({
-            data: {
-                cartridgeComponent: cartridgeConf.cartridge || {component: Empty},
-                summaryComponent: cartridgeConf.summary || {component: Empty},
-                actions: cartridgeConf.actions || {primary: [], secondary: []},
-                barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
-                barContentRightComponent: cartridgeConf.barRight || {component: Empty},
-                headerSize: cartridgeConf.headerSize || 'medium'
-            },
-            type: 'update'
-        });
+        let data = {
+            cartridgeComponent: cartridgeConf.cartridge || {component: Empty},
+            summaryComponent: cartridgeConf.summary || {component: Empty},
+            actions: cartridgeConf.actions || {primary: [], secondary: []},
+            barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
+            headerSize: cartridgeConf.headerSize || 'medium'
+        };
+
+        if (cartridgeConf.barRight) {
+            data.barContentRightComponent = cartridgeConf.barRight;
+        }
+
+        dispatcher.handleViewAction({data, type: 'update'});
     },
 
     /**

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -33,7 +33,7 @@ export default {
             summaryComponent: cartridgeConf.summary || {component: Empty},
             actions: cartridgeConf.actions || {primary: [], secondary: []},
             barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
-            canDeploy: cartridgeConf.canDeploy || true
+            canDeploy: _.isUndefined(cartridgeConf.canDeploy) ? true : cartridgeConf.canDeploy
         };
 
         if (cartridgeConf.barRight) {

--- a/src/page/mixin/cartridge-behaviour.js
+++ b/src/page/mixin/cartridge-behaviour.js
@@ -1,41 +1,50 @@
-var isFunction = require('lodash/lang/isFunction');
-var dispatcher = require('focus-core').dispatcher;
-var Empty = require('../../common/empty').component;
-module.exports = {
+import {isFunction} from 'lodash/lang';
+import {dispatcher} from 'focus-core';
+import {component as Empty} from '../../common/empty';
+
+export default {
+
     /**
-     * Register the cartridge.
+     * Updates the cartridge using the cartridgeConfiguration.
      */
-    _registerCartridge: function registerCartridge(){
-      this.cartridgeConfiguration = this.cartridgeConfiguration || this.props.cartridgeConfiguration;
-      if(!isFunction(this.cartridgeConfiguration)){
-        this.cartridgeConfiguration = function cartridgeConfiguration(){
-          return {};
-        };
-        console.warn(`
-          Your detail page does not have any cartrige configuration, this is not mandarory but recommended.
-          It should be a component attribute return by a function.
-          function cartridgeConfiguration(){
-            var cartridgeConfiguration = {
-              summary: {component: "A React Component", props: {id: this.props.id}},
-              cartridge: {component: "A React Component"},
-              actions: {components: "react actions"}
-            };
-            return cartridgeConfiguration;
-          }
-        `);
-      }
-      var cartridgeConf = this.cartridgeConfiguration();
-      dispatcher.handleViewAction({
-        data: {
-          cartridgeComponent: cartridgeConf.cartridge || {component: Empty},
-          summaryComponent: cartridgeConf.summary|| {component: Empty},
-          actions: cartridgeConf.actions|| {primary: [], secondary: []},
-          barContentLeftComponent: cartridgeConf.barLeft || {component: Empty}
-        },
-        type: 'update'
-      });
+    _registerCartridge() {
+        this.cartridgeConfiguration = this.cartridgeConfiguration || this.props.cartridgeConfiguration;
+
+        if (!isFunction(this.cartridgeConfiguration)) {
+            this.cartridgeConfiguration = () => ({});
+            console.warn(`
+                Your detail page does not have any cartrige configuration, this is not mandarory but recommended.
+                It should be a component attribute return by a function.
+                function cartridgeConfiguration(){
+                    var cartridgeConfiguration = {
+                    summary: {component: "A React Component", props: {id: this.props.id}},
+                    cartridge: {component: "A React Component"},
+                    actions: {components: "react actions"}
+                    };
+                    return cartridgeConfiguration;
+                }
+            `);
+        }
+
+        let cartridgeConf = this.cartridgeConfiguration();
+
+        dispatcher.handleViewAction({
+            data: {
+                cartridgeComponent: cartridgeConf.cartridge || {component: Empty},
+                summaryComponent: cartridgeConf.summary || {component: Empty},
+                actions: cartridgeConf.actions || {primary: [], secondary: []},
+                barContentLeftComponent: cartridgeConf.barLeft || {component: Empty},
+                barContentRightComponent: cartridgeConf.barRight || {component: Empty},
+                headerSize: cartridgeConf.headerSize || 'medium'
+            },
+            type: 'update'
+        });
     },
-    componentWillMount: function pageMixinWillMount(){
-      this._registerCartridge();
+
+    /**
+     * Registers the cartridge upon mounting.
+     */
+    componentWillMount() {
+        this._registerCartridge();
     }
 };


### PR DESCRIPTION
Hello.
As mentionned in #686, which itself referenced other issues people were having with the header and cartridge, I propose here something that would solve most people issues with it (including mine).
(Don't forget the [corresponding PR in focus-core](https://github.com/KleeGroup/focus-core/pull/267))

The end result is this:
![yoloheader](https://cloud.githubusercontent.com/assets/3266897/11961694/716d89dc-a8da-11e5-9549-9e45c29486df.gif)

The header doesn't use a sizeMap or similar tricks anymore, it only has a **isDeployed** state that determines if the cartridge is shown or not, and an associated **canDeploy** prop, which defaults to `true`.
As shown in the gif, the `isDeployed` state changes on its own when the header has the size of the `top-bar`. Of course, if `canDeploy`is false, the header will stay collapsed whatever happens.

The cartridgeConfiguration (and applicationStore) has been updated with the `canDeploy` prop, and you can also now optionally set the barRight component too with it.

There is then no need to mess with the `data-route` to change the header size any more.

Hope it works for everybody.

### What's changing
* The css selector `[data-size='small']` has been replaced by `[data-deployed='false']`. Similarly, `[data-size="medium']` by `[data-deployed='true']`. They are now directly linked to the current shown component : `true` -> cartridge shown, `false` -> summary shown, always. Thus, **`data-size` has been removed.**
* `sizeMap` and `processSizes` have been removed.
* `notifySizeChange` is still here but is given the `isDeployed` state as parameter.