### PR TITLE
[Search-bar] Add possibility to specify icon and library in scope, differently than using the code

### DIFF
--- a/src/search/search-bar/scope.js
+++ b/src/search/search-bar/scope.js
@@ -99,14 +99,13 @@ const scopeMixin = {
         return (
             <ul className={`mdl-menu mdl-menu--bottom-left mdl-js-menu mdl-js-ripple-effect`} data-focus='search-bar-scopes' htmlFor={scopesId} ref='scopeDropdown'>
                 {0 < scopeList.length && scopeList.map(scope => {
-                    const {code, label, ...otherScopeProps} = scope;
-                    const icon = scope.icon ? scope.icon : code; //legacy
+                    const {code, icon, label, ...otherScopeProps} = scope;
                     const scopeId = uniqueId('scopes_');
                     const isActive = value === code;
                     return (
                         <li className='mdl-menu__item' data-active={isActive} key={scope.code || scopeId} data-scope={scope.code || scopeId} onClick={this._getScopeClickHandler(scope)}>
                             {scope.code &&
-                                <Icon name={icon} {...otherScopeProps}/>
+                                <Icon name={icon || code} {...otherScopeProps}/>
                             }
                             <span>{this.i18n(label)}</span>
                         </li>
@@ -127,12 +126,11 @@ const scopeMixin = {
     render() {
         const {scopesId} = this;
         const activeScope = this._getActiveScope();
-        const {code, label, ...otherScopeProps} = activeScope;
-        const icon = activeScope.icon ? activeScope.icon : code; //legacy
+        const {code, icon, label, ...otherScopeProps} = activeScope;
         return (
             <div data-focus='search-bar-scope'>
                 <button className='mdl-button mdl-js-button' id={scopesId} data-scope={code}>
-                    <Icon name={icon} {...otherScopeProps}/>
+                    <Icon name={icon || code} {...otherScopeProps}/>
                     <span>{this.i18n(label)}</span>
                 </button>
                 {this._renderScopeList()}

--- a/src/search/search-bar/scope.js
+++ b/src/search/search-bar/scope.js
@@ -100,12 +100,13 @@ const scopeMixin = {
             <ul className={`mdl-menu mdl-menu--bottom-left mdl-js-menu mdl-js-ripple-effect`} data-focus='search-bar-scopes' htmlFor={scopesId} ref='scopeDropdown'>
                 {0 < scopeList.length && scopeList.map(scope => {
                     const {code, label, ...otherScopeProps} = scope;
+                    const icon = scope.icon ? scope.icon : code; //legacy
                     const scopeId = uniqueId('scopes_');
                     const isActive = value === code;
                     return (
                         <li className='mdl-menu__item' data-active={isActive} key={scope.code || scopeId} data-scope={scope.code || scopeId} onClick={this._getScopeClickHandler(scope)}>
                             {scope.code &&
-                                <Icon name={code} {...otherScopeProps}/>
+                                <Icon name={icon} {...otherScopeProps}/>
                             }
                             <span>{this.i18n(label)}</span>
                         </li>
@@ -127,10 +128,11 @@ const scopeMixin = {
         const {scopesId} = this;
         const activeScope = this._getActiveScope();
         const {code, label, ...otherScopeProps} = activeScope;
+        const icon = activeScope.icon ? activeScope.icon : code; //legacy
         return (
             <div data-focus='search-bar-scope'>
                 <button className='mdl-button mdl-js-button' id={scopesId} data-scope={code}>
-                    <Icon name={code} {...otherScopeProps}/>
+                    <Icon name={icon} {...otherScopeProps}/>
                     <span>{this.i18n(label)}</span>
                 </button>
                 {this._renderScopeList()}


### PR DESCRIPTION
## Issue Description

In previous versions, scope codes were used to specify the code of scope used for research but also to declare scope icon name. But most of times, we don't want to use the same code for scope and icon. Inded, icon libraries have proper names.

```javascript
{code: 'ALL', label: 'search.scope.all'},
{code: 'MOVIE', label: 'search.scope.movie'},
{code: 'PERSON',  label: 'search.scope.person'}
```

![image](https://cloud.githubusercontent.com/assets/5349745/12022858/36d6888c-ad94-11e5-89a3-cdff3f137eee.png)


## Patch

It is now possible to specify the icon name and library by specify it on the scope, like this : 

```javascript
{code: 'ALL', icon: 'all_inclusive', label: 'search.scope.all'},
{code: 'MOVIE', icon: 'movie', library:'material', label: 'search.scope.movie'},
{code: 'PERSON', icon: 'person', label: 'search.scope.person'}
```

> Fixes #834 

![image](https://cloud.githubusercontent.com/assets/5349745/12023007/6d5961ee-ad95-11e5-9546-0bfa0c5086af.png)
