### PR TITLE
correct icon rendering on button when no icon is specified

### DIFF
--- a/src/common/button/action/index.js
+++ b/src/common/button/action/index.js
@@ -123,10 +123,10 @@ const buttonMixin = {
     },
     /** inheritedDoc */
     render() {
-        const {className, id, type, label, style, ...otherProps} = this.props;
+        const {className, icon, id, type, label, style, ...otherProps} = this.props;
         return (
             <button alt={this.i18n(label)} className={`${className} ${this._getComponentClassName()}`} data-focus='button-action' id={id} onClick={this.handleOnClick} title={this.i18n(label)} type={type} {...otherProps}>
-                {this._renderIcon()}
+                {icon && this._renderIcon()}
                 {this._renderLabel()}
             </button>
         );


### PR DESCRIPTION
## Issue Description

Following the Focus version 0.8.3 update, buttons' content is now off by several pixels (1 em = 24px)
Seems like the CSS class material-icons' width has been modified

![image](https://cloud.githubusercontent.com/assets/8983628/11978425/dae399ae-a98b-11e5-8774-eb691c37c23b.png)

# Patch

when icon is not specified, it is not rendered in button.

Fixes #828 
