### PR TITLE
[Button] correct icon rendering on button when no icon is specified

### DIFF
--- a/src/common/button/action/index.js
+++ b/src/common/button/action/index.js
@@ -38,7 +38,7 @@ const buttonMixin = {
             type: 'submit',
             shape: 'raised',
             label: '',
-            icon: '',
+            icon: null,
             id: '',
             hasRipple: false,
             isJs: false,


### PR DESCRIPTION
improve PR #840.

Fixes #828 

Now <span> is not rendered when no icon is specified.