### PR TITLE
Change panel name in loading css

### DIFF
--- a/src/common/form/style/form.scss
+++ b/src/common/form/style/form.scss
@@ -2,7 +2,7 @@ form {
     margin: 0;
     padding: 0;
     &[data-loading='true'] {
-        [data-focus="block"]{
+        [data-focus='panel']{
             position: relative;
             &:after {
                 content: 'Loading...';


### PR DESCRIPTION
# Description

The loading state of the block was no longer displayed due to a CSS issue.

It should fix #618 #779 #823