### PR TITLE
[Advanced-search] Search was launch 3 times

### DIFF
--- a/src/page/search/advanced-search/index.js
+++ b/src/page/search/advanced-search/index.js
@@ -97,9 +97,10 @@ const AdvancedSearch = {
     * Register the store listeners
     */
     componentWillMount() {
-        ['query', 'scope', 'selected-facets', 'grouping-key', 'sort-by', 'sort-asc'].forEach((node) => {
-            this.props.store[`add${capitalize(camel(node))}ChangeListener`](this._onStoreChangeWithSearch);
-        });
+        //listen to search event
+        this.props.store.on('advanced-search-criterias:change', this._onStoreChangeWithSearch);
+
+        //listen to data changes
         ['facets', 'results', 'total-count'].forEach((node) => {
             this.props.store[`add${capitalize(camel(node))}ChangeListener`](this._onStoreChangeWithoutSearch);
         });
@@ -110,16 +111,12 @@ const AdvancedSearch = {
         });
         this._action.search();
     },
-    componentDidMount() {
-
-    },
     /**
     * Un-register the store listeners
     */
     componentWillUnmount() {
-        ['query', 'scope', 'selected-facets', 'grouping-key', 'sort-by', 'sort-asc'].forEach(node => {
-            this.props.store[`remove${capitalize(camel(node))}ChangeListener`](this._onStoreChangeWithSearch);
-        });
+        // remove listeners
+        this.props.store.removeListener('advanced-search-criterias:change', this._onStoreChangeWithSearch);
         ['facets', 'results', 'total-count'].forEach((node) => {
             this.props.store[`remove${capitalize(camel(node))}ChangeListener`](this._onStoreChangeWithoutSearch);
         });


### PR DESCRIPTION
## Issue

Advanced search was launched 3 times is some cases (when more than one criteria is changed).

## Patch

This behaviour is now corrected. Advanced search is now always launched onces, even all of criterias are launched.

## Focus-core

Associated to : https://github.com/KleeGroup/focus-core/pull/279
