### PR TITLE
[Quick-Serch] correct event listener in quick search

### DIFF
--- a/src/page/search/quick-search/index.js
+++ b/src/page/search/quick-search/index.js
@@ -35,7 +35,7 @@ const QuickSearchComponent = {
     /**
     * Tag name.
     */
-    displayName: 'quick-search',
+    displayName: 'QuickSearch',
     /**
     * Reference names to be fetched by the reference behaviour
     * @type {Array}
@@ -88,8 +88,10 @@ const QuickSearchComponent = {
             getSearchOptions: () => {return store.getValue.call(store); } // Binding the store in the function call
         });
         this._loadReference();
-        store.addQueryChangeListener(this._triggerSearch);
-        store.addScopeChangeListener(this._triggerSearch);
+
+        store.on('quick-search-criterias:change', this._triggerSearch);
+        // store.addQueryChangeListener(this._triggerSearch);
+        // store.addScopeChangeListener(this._triggerSearch);
         store.addResultsChangeListener(this._onResultsChange);
     },
     /**
@@ -97,8 +99,9 @@ const QuickSearchComponent = {
     */
     componentWillUnmount() {
         const {store} = this.props;
-        store.removeQueryChangeListener(this._triggerSearch);
-        store.removeScopeChangeListener(this._triggerSearch);
+        store.removeListener('quick-search-criterias:change', this._triggerSearch);
+        // store.removeQueryChangeListener(this._triggerSearch);
+        // store.removeScopeChangeListener(this._triggerSearch);
         store.removeResultsChangeListener(this._onResultsChange);
     },
     /**


### PR DESCRIPTION
## Issue

Quick search was launched 3 times is some cases (when more than one criteria is changed).

## Patch

This behaviour is now corrected. Quick search is now always launched onces, even all of criterias are launched.

## Focus-components

Associated to : https://github.com/KleeGroup/focus-core/pull/291