### PR TITLE
[Field-Grid-Behaviour] Adding optional props + Correction of incorrect class

### DIFF
--- a/src/common/mixin/field-grid-behaviour.js
+++ b/src/common/mixin/field-grid-behaviour.js
@@ -4,7 +4,18 @@ const {PropTypes} = React;
 
 
 const GRID_SIZE = 12, CELL = 'mdl-cell';
-
+/**
+ * An example of the label and content size, and of label and content offset, with function fieldFor
+ * 
+ * I want to have the label on the first row of the grid, the field on the second one,
+ * with a 'padding' (offset) of one cell on each row.
+ * 
+ * const fieldOptions = { labelSize: 10, contentSize: 10, labelOffset:1, contentOffset:1 };
+ * ...
+ * {this.fieldFor('nom', fieldOptions)}
+ * 
+ **/
+ 
 const fieldGridBehaviourMixin = {
     /** @inheritdoc */
     getDefaultProps(){
@@ -39,7 +50,7 @@ const fieldGridBehaviourMixin = {
     },
     _buildGridClassName : function _buildGridClassName (prop, suffix){
 		return prop?(' mdl-cell--' + prop + (suffix ? suffix : '')):'';
-	},
+    },
     _getCellGridClassName: function _getCellGridClassName(position,size, offset) {
 		const cellPosition = this._buildGridClassName(position);
 		const cellSize = this._buildGridClassName(size, '-col');
@@ -47,7 +58,7 @@ const fieldGridBehaviourMixin = {
 
         return CELL + cellPosition + cellSize + cellOffset;
     },
-	/**
+    /**
     * Get the label gridClass.
     * @returns {string} - The label gridSize.
     */

--- a/src/common/mixin/field-grid-behaviour.js
+++ b/src/common/mixin/field-grid-behaviour.js
@@ -33,21 +33,33 @@ const fieldGridBehaviourMixin = {
         contentCellPosition: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         labelCellPosition: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         labelSize: PropTypes.number,
-        contentSize: PropTypes.number
+        contentSize: PropTypes.number,
+        labelOffset: PropTypes.number,
+        contentOffset: PropTypes.number
     },
-    /**
+    _buildGridClassName : function _buildGridClassName (prop, suffix){
+		return prop?(' mdl-cell--' + prop + (suffix ? suffix : '')):'';
+	},
+    _getCellGridClassName: function _getCellGridClassName(position,size, offset) {
+		const cellPosition = this._buildGridClassName(position);
+		const cellSize = this._buildGridClassName(size, '-col');
+		const cellOffset = this._buildGridClassName(offset, '-offset');
+
+        return CELL + cellPosition + cellSize + cellOffset;
+    },
+	/**
     * Get the label gridClass.
     * @returns {string} - The label gridSize.
     */
-    _getLabelGridClassName(){
-        return `${CELL} mdl-cell--${this.props.labelCellPosition} mdl-cell--${this.props.labelSize}-col`;
-    },
+    _getLabelGridClassName: function _getLabelGridClassName() {
+		return this._getCellGridClassName(this.props.labelCellPosition, this.props.labelSize, this.props.labelOffset);
+	},
     /**
     * Get the content class Name.
     * @returns {string} - The content gridSize.
     */
-    _getContentGridClassName(){
-        return `${CELL} mdl-cell--${this.props.contentCellPosition} mdl-cell--${this.props.contentSize || (GRID_SIZE - this.props.labelSize)}-col`;
+    _getContentGridClassName: function _getContentGridClassName() {
+		return this._getCellGridClassName(this.props.contentCellPosition, (this.props.contentSize || (GRID_SIZE - this.props.labelSize)), this.props.contentOffset);
     },
     /**
     * Get the content offset className.

--- a/src/common/mixin/field-grid-behaviour.js
+++ b/src/common/mixin/field-grid-behaviour.js
@@ -32,7 +32,8 @@ const fieldGridBehaviourMixin = {
     propTypes: {
         contentCellPosition: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         labelCellPosition: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-        labelSize: PropTypes.number
+        labelSize: PropTypes.number,
+        contentSize: PropTypes.number
     },
     /**
     * Get the label gridClass.
@@ -46,14 +47,14 @@ const fieldGridBehaviourMixin = {
     * @returns {string} - The content gridSize.
     */
     _getContentGridClassName(){
-        return `${CELL} mdl-cell--${this.props.contentCellPosition} mdl-cell--${GRID_SIZE - this.props.labelSize}-col`;
+        return `${CELL} mdl-cell--${this.props.contentCellPosition} mdl-cell--${this.props.contentSize || (GRID_SIZE - this.props.labelSize)}-col`;
     },
     /**
     * Get the content offset className.
     * @returns {string} - The label gridSize.
     */
     _getContentOffsetClassName(){
-        return `${CELL} mdl-cell--${this.props.labelSize}-offset-col`;
+        return `${CELL} mdl-cell--${this.props.labelSize}-offset`;
     }
 };
 module.exports = fieldGridBehaviourMixin;


### PR DESCRIPTION
Adding optional prop 'contentSize' : allow to have label and field on different rows
Correcting the offset class for material design (https://github.com/google/material-design-lite/tree/master/src/grid)

Also adding options to manage offset on label and content