### PR TITLE
setting height for actions so that they stay aligned even when one ac…

### DIFF
--- a/src/list/action-bar/style/index.js
+++ b/src/list/action-bar/style/index.js
@@ -15,13 +15,15 @@ const style = {
             position: 'relative',
             top: '-33px',
             left: '40px',
-            width: '40px'
+            width: '40px',
+            height: '30px'
         },
         group: {
             position: 'relative',
             top: '-64px',
             left: '80px',
-            width: '40px'
+            width: '40px',
+            height: '30px'
         }
     }
 };


### PR DESCRIPTION
…tion is not displayed

When setting no sort, the group icon is way high on the screen (since no sort is displayed, the -64px is summed to the -33px)
If the height is set, then things are right.