### PR TITLE
[selection-line] Fix update selection on re-rendering.

### DIFF
--- a/src/list/selection/line.js
+++ b/src/list/selection/line.js
@@ -2,6 +2,7 @@
 
 import types from 'focus-core/component/types';
 const React = require('react');
+import isEqual from 'lodash/lang/isEqual';
 
 // Components
 
@@ -81,10 +82,12 @@ const lineMixin = {
      * @param  {object} nextProps new component's props
      */
     componentWillReceiveProps({isSelected, data}) {
-        if (data !== this.props.data) {
+        if (isEqual(data,this.props.data)) {
+            if (isSelected !== undefined) {
+                this.setState({isSelected});
+            }
+        } else {
             this.setState({isSelected: false});
-        } else if (isSelected !== undefined) {
-            this.setState({isSelected});
         }
     },
 


### PR DESCRIPTION
## Issue

When the list receives new props, the selection is lost even if the new props are identical from the current props.

![selection-list-issue](https://cloud.githubusercontent.com/assets/15649023/12718928/353ee284-c8f2-11e5-81a6-f74f8a0c0401.gif)

## Patch

Now when the data are identical, the list keeps its selection.