### PR TITLE
[Select-radio] add disabled mode

### DIFF
--- a/src/common/input/radio/index.js
+++ b/src/common/input/radio/index.js
@@ -75,13 +75,15 @@ const radioMixin = {
     */
     render() {
         const {isChecked} = this.state;
-        const {label, name} = this.props;
+        const {label, name, disabled} = this.props;
         // we use inputProps to be able to display 'checked' property. it is required to be able to use MDL.
         const checkedProps = isChecked ? {checked: 'checked'} : {};
-        const inputProps = {...{className: 'mdl-radio__button', name: name, onChange: this._onChange, type: 'radio'}, ...checkedProps};
+        const disabledProps = disabled ? {disabled: 'disabled'} : {};
+        const inputProps = {...{className: 'mdl-radio__button', name: name, onChange: this._onChange, type: 'radio'}, ...checkedProps, ...disabledProps};
+
         return (
             <label className='mdl-radio mdl-js-radio mdl-js-ripple-effect' data-focus="input-radio" ref='inputMdl'>
-                <input {...inputProps} />
+                <input {...inputProps}/>
                 <span className='mdl-radio__label'>{this.i18n(label)}</span>
             </label>
         );

--- a/src/common/input/radio/index.js
+++ b/src/common/input/radio/index.js
@@ -75,11 +75,10 @@ const radioMixin = {
     */
     render() {
         const {isChecked} = this.state;
-        const {label, name, disabled} = this.props;
+        const {label, name, ...otherProps} = this.props;
         // we use inputProps to be able to display 'checked' property. it is required to be able to use MDL.
         const checkedProps = isChecked ? {checked: 'checked'} : {};
-        const disabledProps = disabled ? {disabled: 'disabled'} : {};
-        const inputProps = {...{className: 'mdl-radio__button', name: name, onChange: this._onChange, type: 'radio'}, ...checkedProps, ...disabledProps};
+        const inputProps = {...{className: 'mdl-radio__button', name: name, onChange: this._onChange, type: 'radio'}, ...checkedProps, ...otherProps};
 
         return (
             <label className='mdl-radio mdl-js-radio mdl-js-ripple-effect' data-focus="input-radio" ref='inputMdl'>

--- a/src/common/select/radio/index.js
+++ b/src/common/select/radio/index.js
@@ -18,7 +18,8 @@ const selectRadioMixin = {
         return {
             values: [],
             valueKey: 'code',
-            labelKey: 'label'
+            labelKey: 'label',
+            disabled: false
         };
     },
 
@@ -28,7 +29,8 @@ const selectRadioMixin = {
         value: types(['number', 'string', 'array']),
         valueKey: types('string'),
         labelKey: types('string'),
-        onChange: types('func')
+        onChange: types('func'),
+        disabled: types('bool')
     },
 
     /** @inheritdoc */
@@ -86,9 +88,10 @@ const selectRadioMixin = {
         return this.props.values.map((val, idx)=>{
             const value = val[this.props.valueKey];
             const label = val[this.props.labelKey];
+            const disabled = this.props.disabled;;
             const isChecked = value === this.state.value;
             return (
-                <InputRadio key={idx} label={this.i18n(label)} name={uniqueName} onChange={this._getRadioChangeHandler(value)} value={isChecked} />
+                <InputRadio key={idx} label={this.i18n(label)} name={uniqueName} onChange={this._getRadioChangeHandler(value)} value={isChecked} disabled={disabled} />
             );
         });
     },

--- a/src/common/select/radio/index.js
+++ b/src/common/select/radio/index.js
@@ -85,10 +85,10 @@ const selectRadioMixin = {
     */
     renderSelectRadios() {
         const {uniqueName} = this.state;
-        return this.props.values.map((val, idx)=>{
+        return this.props.values.map((val, idx) => {
             const value = val[this.props.valueKey];
             const label = val[this.props.labelKey];
-            const disabled = this.props.disabled;;
+            const disabled = this.props.disabled;
             const isChecked = value === this.state.value;
             return (
                 <InputRadio key={idx} label={this.i18n(label)} name={uniqueName} onChange={this._getRadioChangeHandler(value)} value={isChecked} disabled={disabled} />


### PR DESCRIPTION
## Issue Description

Currently, it is impossible to display a disabled selectRadio. 

## Patch

disabled property has been added

modified files:

* src/common/input/radio/index.js
* src/common/select/radio/index.js

### Example:
```jsx
render() {
        const valuesExample = [
            {code: 'A', label: 'aaaa'},
            {code: 'B', label: 'bbbbb'},
            {code: 'C', label: 'ccccc'},
            {code: 'D', label: 'DDDD'}
        ];
        return (

                <SelectRadio value='A' values={valuesExample} disabled={true}/>

        );
    }
```

## Fixes
It fixes #653 