### PR TITLE
[Search-bar] fix spinner default size

### DIFF
--- a/src/search/search-bar/style/search-bar.scss
+++ b/src/search/search-bar/style/search-bar.scss
@@ -39,11 +39,11 @@ $search-bar-border-bottom:1px solid rgba(0, 0, 0, 0.117647);
             position: absolute;
             right: 10px;
             top: 14px;
-            border: 2px solid #38e;
+            border: 3px solid #38e;
             border-right-color: transparent;
-            border-radius: 16px;
-            width: 20px;
-            height: 20px;
+            border-radius: 10px;
+            width: 15px;
+            height: 15px;
         }
     }
 }


### PR DESCRIPTION
The search-bar spinner default size is corrected to fit by default in the container.