### PR TITLE
[selection-list] fix props in line component call.

### DIFF
--- a/src/list/selection/list.js
+++ b/src/list/selection/list.js
@@ -154,13 +154,13 @@ const listMixin = {
             }
             return (
                 <FinalLineComponent
+                    {...otherProps}
                     data={line}
                     isSelected={isSelected}
                     key={line[idField] || idx}
                     onSelection={this._handleLineSelection}
                     ref={`line${idx}`}
                     reference={this._getReference()}
-                    {...otherProps}
                     />
             );
         });


### PR DESCRIPTION
## Issue
When giving a custom onSelection() props to list component, the list component itself give this custom onSelection() to the line component, instead of giving its own onSelection() called _handleLineSelection() which calls onSelection() anyway.

### Explicative list component schema:
```
_handleLineSelection() {
  ...
  this.props.onSelection()
}

<LineComponent
  onSelection = {this._handleLineSelection}
  onSelection = {this.props.onSelection}
>
```

## Patch
  Changed props order in Line Component call. This way, Line Component receives _handleLineSelection anyway.
