### PR TITLE
Add 'unit' and 'inputWidth' prop to InputText (and support them for domain definition).

### DIFF
--- a/src/common/mixin/field-component-behaviour.js
+++ b/src/common/mixin/field-component-behaviour.js
@@ -52,6 +52,8 @@ const fieldBehaviourMixin = {
             style: options.style,
 			// Type
 			type: def.type,
+            unit: def.unit,
+            inputWidth: def.inputWidth,
             //Methods
             validator: def.validator,
             formatter: def.formatter || identity,

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -60,16 +60,20 @@ class InputText extends Component {
      * @override
     */
     render() {
-        const {error, name, placeholder, style, value: rawValue, formatter, ...otherProps} = this.props;
+        const {error, name, placeholder, style, value: rawValue, formatter, unit, inputWidth, ...otherProps} = this.props;
         const value = formatter(rawValue, MODE);
         const pattern = error ? 'hasError' : null; //add pattern to overide mdl error style when displaying an focus error.
         const inputProps = {...otherProps, value, id: name, onChange: this._handleInputChange, pattern};
         const cssClass = `mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`;
+        const computedStyle = inputWidth ? {...style, width: `${inputWidth}px`} : style;
         return (
-            <div className={cssClass} data-focus='input-text' ref='inputText' style={style}>
-                <input className='mdl-textfield__input' ref='htmlInput' {...inputProps} />
-                <label className='mdl-textfield__label' htmlFor={name}>{this.i18n(placeholder)}</label>
-                {error && <span className='mdl-textfield__error'>{error}</span>}
+            <div style={{display: 'flex'}}>
+                <div className={cssClass} data-focus='input-text' ref='inputText' style={computedStyle}>
+                    <input className='mdl-textfield__input' ref='htmlInput' {...inputProps} />
+                    <label className='mdl-textfield__label' htmlFor={name}>{this.i18n(placeholder)}</label>
+                    {error && <span className='mdl-textfield__error'>{error}</span>}
+                </div>
+                <div style={{margin: '5px 0 0 5px'}}>{unit}</div>
             </div>
         );
     }


### PR DESCRIPTION
You can know specify a 'unit' and and 'inputWidth' to an `InputText` field (the default one when using `this.fieldFor()` that will respectively add whatever text you want right of the input field and set the width of the textfield to whatever value you want (Focus default is 300px).

Example:
![exemple](https://cloud.githubusercontent.com/assets/3266897/12950591/3bd88aaa-d00e-11e5-9c55-39cb89f24d20.PNG)

You can set them in the domain config (next to `formatter`, `validator`...) and override them in the `options` parameter of `fieldFor`.