### PR TITLE
Fix textarea on IE

### DIFF
--- a/src/components/input/textarea/index.js
+++ b/src/components/input/textarea/index.js
@@ -29,7 +29,6 @@ const defaultProps = {
     type: 'text',
     formatter: identity,
     unformatter: identity,
-    maxLength: -1,
     minLength: 0,
     wrap: 'soft',
     //required: false,


### PR DESCRIPTION
Attribute `max-length=-1` has the same behaviour as `max-length=0` on IE11 (and probably older versions too), so you can't enter anything by default.