### PR TITLE
Add unit call to getStateFromStore.

### DIFF
--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -1,6 +1,7 @@
 const capitalize = require('lodash/string/capitalize');
 const assign = require('object-assign');
 const {isObject, isArray} = require('lodash/lang');
+const contains = require('lodash/array/contains');
 const keys = require('lodash/object/keys');
 const storeChangeBehaviour = require('./store-change-behaviour');
 
@@ -8,17 +9,18 @@ const storeMixin = {
   mixins: [storeChangeBehaviour],
   /**
    * Get the state informations from the store.
+   * @param {string} property - The name of the store property.
    * @returns {object} - The js object constructed from store data.
    */
-  _getStateFromStores: function formGetStateFromStore() {
+  _getStateFromStores: function formGetStateFromStore(property) {
     if (this.getStateFromStore) {
-      return this.getStateFromStore();
+      return this.getStateFromStore(property);
     }
     let newState = {};
     this.stores.map((storeConf) => {
-      storeConf.properties.map((property)=>{
-        newState[property] = storeConf.store[`get${capitalize(property)}`]();
-      });
+        if (contains(storeConf.properties, property)) {
+            newState[property] = storeConf.store[`get${capitalize(property)}`]();
+        }
     });
     const computedState = assign(this._computeEntityFromStoresData(newState), this._getLoadingStateFromStores());
     return computedState;
@@ -72,7 +74,7 @@ const storeMixin = {
     if(this.computeEntityFromStoresData){
       return this.computeEntityFromStoresData(data);
     }
-    var entity = {reference: {}};
+    var entity = {reference: this.state && this.state.reference || {}};
     for(var key in data){
       if(this.referenceNames && this.referenceNames.indexOf(key) !== -1 ){
         entity.reference[key] = data[key];

--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -1,18 +1,19 @@
 const capitalize = require('lodash/string/capitalize');
 const assign = require('object-assign');
 const {isObject, isArray} = require('lodash/lang');
-const contains = require('lodash/array/contains');
+const contains = require('lodash/collection/contains');
 const keys = require('lodash/object/keys');
 const storeChangeBehaviour = require('./store-change-behaviour');
 
 const storeMixin = {
   mixins: [storeChangeBehaviour],
+
   /**
-   * Get the state informations from the store.
-   * @param {string} property - The name of the store property.
+   * Loads a store node and puts the data in the state.
+   * @param {string} property - The name of the store node.
    * @returns {object} - The js object constructed from store data.
    */
-  _getStateFromStores: function formGetStateFromStore(property) {
+  _getStateFromStore: function formGetStateFromStore(property) {
     if (this.getStateFromStore) {
       return this.getStateFromStore(property);
     }
@@ -25,6 +26,25 @@ const storeMixin = {
     const computedState = assign(this._computeEntityFromStoresData(newState), this._getLoadingStateFromStores());
     return computedState;
   },
+
+  /**
+   * Loads all store nodes and puts the data in the state.
+   * @returns {object} - The js object constructed from store data.
+   */
+  _getStateFromStores: function formGetStateFromStores() {
+    if (this.getStateFromStore) {
+      return this.getStateFromStore();
+    }
+    let newState = {};
+    this.stores.map((storeConf) => {
+        storeConf.properties.map((property)=>{
+            newState[property] = storeConf.store[`get${capitalize(property)}`]();
+        });
+    });
+    const computedState = assign(this._computeEntityFromStoresData(newState), this._getLoadingStateFromStores());
+    return computedState;
+  },
+
     /**
      * Get the error state informations from the store.
      * @returns {object} - The js error object constructed from the store data.

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -61,7 +61,7 @@ const changeBehaviourMixin = {
         if (onChange) {
             onChange.call(this, changeInfos);
         }
-        this.setState(this._getStateFromStores(changeInfos.property), () => this._afterChange(changeInfos));
+        this.setState(this._getStateFromStore(changeInfos.property), () => this._afterChange(changeInfos));
     },
     /**
      * Event handler for 'error' events coming from the stores.

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -61,7 +61,7 @@ const changeBehaviourMixin = {
         if (onChange) {
             onChange.call(this, changeInfos);
         }
-        this.setState(this._getStateFromStores(), () => this._afterChange(changeInfos));
+        this.setState(this._getStateFromStores(changeInfos.property), () => this._afterChange(changeInfos));
     },
     /**
      * Event handler for 'error' events coming from the stores.


### PR DESCRIPTION
For the longest time, we've all been suffering from a bad design choice that forced us to hack our way through to get the expected behaviour.
I'm talking about the `getStateFromStores` method which reloads the entire state of a component from the whole bunch of stores it listens to, when all I wanted to do was to reload one single store. 

Not anymore. 

`_getStateFromStores` is now called with a `property` param in the `_onChange` method which allows it (by default) to only reload the store I modified.

It's pretty transparent for everyone, since it doesn't interfere with any overrides. The only thing that changes is if you called directly `_getStateFromStores` in user code expecting it to reload everything, but I'd say it's not a very good practice (and reimplementing it the way it worked could be easily done if this PR).