### PR TITLE
Fix field error setting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 [Description of the issue fixed or the new feature]
 [Screenshots if possible in case of a new feature]
+
 ### Patch [in case of a fix]
 
 [Description of the fix]

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -1,12 +1,13 @@
 import message from 'focus-core/message';
 import {changeMode} from 'focus-core/application';
+import reduce from 'lodash/collection/reduce';
 
 const changeBehaviourMixin = {
     /**
-     * Display a message when there is a change on a store property resulting from a component action call.
-     * @param  {object} changeInfos - An object containing all the event informations, without the data.
-     * @return {function} - An override function can be called.
-     */
+    * Display a message when there is a change on a store property resulting from a component action call.
+    * @param  {object} changeInfos - An object containing all the event informations, without the data.
+    * @return {function} - An override function can be called.
+    */
     _displayMessageOnChange: function displayMessageOnChange(changeInfos) {
         if (this.displayMessageOnChange) {
             return this.displayMessageOnChange(changeInfos);
@@ -14,33 +15,33 @@ const changeBehaviourMixin = {
         if (changeInfos && changeInfos.status && changeInfos.status.name) {
             switch (changeInfos.status.name) {
                 /* case 'loading':
-                 Focus.message.addInformationMessage('detail.loading');
-                 break;
-                 case 'loaded':
-                 Focus.message.addSuccessMessage('detail.loaded');
-                 break;
-                 case 'saving':
-                 Focus.message.addInformationMessage('detail.saving');
-                 break;*/
+                Focus.message.addInformationMessage('detail.loading');
+                break;
+                case 'loaded':
+                Focus.message.addSuccessMessage('detail.loaded');
+                break;
+                case 'saving':
+                Focus.message.addInformationMessage('detail.saving');
+                break;*/
                 case 'saved':
-                    //Maybe the action result or the event should have a caller notion.
-                    message.addSuccessMessage('detail.saved');
-                    //Change the page mode as edit
-                    this.setState({isEdit: false}, () => {
-                      changeMode('consult', 'edit');
-                    });
-                    break;
+                //Maybe the action result or the event should have a caller notion.
+                message.addSuccessMessage('detail.saved');
+                //Change the page mode as edit
+                this.setState({isEdit: false}, () => {
+                    changeMode('consult', 'edit');
+                });
+                break;
                 default:
-                    break;
+                break;
             }
         }
     },
     /**
-     * After change informations.
-     * You can override this method using afterChange function.
-     * @param {object} changeInfos - All informations relative to the change.
-     * @returns {undefined} -  The return value is the callback.
-     */
+    * After change informations.
+    * You can override this method using afterChange function.
+    * @param {object} changeInfos - All informations relative to the change.
+    * @returns {undefined} -  The return value is the callback.
+    */
     _afterChange: function afterChangeForm(changeInfos) {
         if (this.afterChange) {
             return this.afterChange(changeInfos);
@@ -53,9 +54,9 @@ const changeBehaviourMixin = {
 
     },
     /**
-     * Event handler for 'change' events coming from the stores
-     * @param {object} changeInfos - The changing informations.
-     */
+    * Event handler for 'change' events coming from the stores
+    * @param {object} changeInfos - The changing informations.
+    */
     _onChange: function onFormStoreChangeHandler(changeInfos) {
         let onChange = this.props.onChange || this.onChange;
         if (onChange) {
@@ -64,22 +65,31 @@ const changeBehaviourMixin = {
         this.setState(this._getStateFromStores(), () => this._afterChange(changeInfos));
     },
     /**
-     * Event handler for 'error' events coming from the stores.
-     */
+    * Event handler for 'error' events coming from the stores.
+    */
     _onError: function onFormErrorHandler(changeInfos) {
         const errorState = this._getErrorStateFromStores();
-        for (let key in errorState) {
-            if (this.refs[key]) {
-                this.refs[key].setError(errorState[key]);
+        if (this.definitionPath) {
+            for (let key in errorState) {
+                const ref = reduce(this.refs, (acc, value, candidateRef) => {
+                    const candidate = candidateRef.replace(`${this.definitionPath}.`, '');
+                    if (candidate === key.match(/([^\.]*)$/)[0]) {
+                        acc = value;
+                    }
+                    return acc;
+                }, null);
+                if (ref) {
+                    ref.setError(errorState[key]);
+                }
             }
         }
         this.setState(this._getLoadingStateFromStores()); // update status after errors
     },
     /**
-     * Read
-     * @param  {[type]} changeInfos [description]
-     * @return {[type]}             [description]
-     */
+    * Read
+    * @param  {[type]} changeInfos [description]
+    * @return {[type]}             [description]
+    */
     _onStatus(changeInfos) {
         if (this._getEntity) {
             this.setState({...this._getEntity(), ...this._getLoadingStateFromStores()});

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -70,15 +70,17 @@ const changeBehaviourMixin = {
     _onError: function onFormErrorHandler(changeInfos) {
         const errorState = this._getErrorStateFromStores();
         if (this.definitionPath) {
+            // In case we have a definitionPath, we might want to trigger a setError on the corresponding field
             for (let key in errorState) {
+                // Let's find that corresponding field, considering that the ref might not directly be 'storeNode.fieldName', but in fact 'entityPath.fieldName'
                 const ref = reduce(this.refs, (acc, value, candidateRef) => {
-                    const candidate = candidateRef.replace(`${this.definitionPath}.`, '');
-                    if (candidate === key.match(/([^\.]*)$/)[0]) {
+                    const candidate = candidateRef.replace(`${this.definitionPath}.`, ''); // Remove the 'definitionPath.'
+                    if (candidate === key.match(/([^\.]*)$/)[0]) { // Look for the 'fieldName' part of 'storeNode.fieldName'
                         acc = value;
                     }
                     return acc;
                 }, null);
-                if (ref) {
+                if (ref) { // If we found it, then bingo
                     ref.setError(errorState[key]);
                 }
             }


### PR DESCRIPTION
## [Form] Fix field error setting

### Description

In a `Field`, when the `entityPath` is different from the `store node`, a server-sent field error is not set on the field, due to a bad `ref` search.

### Patch

The correct `ref` to the field is now computed from the field name.