### PR TITLE
Fixing ./style which breaked the showcase

### DIFF
--- a/src/page/search/advanced-search/index.js
+++ b/src/page/search/advanced-search/index.js
@@ -63,8 +63,7 @@ const AdvancedSearch = {
             groupComponent: undefined,
             lineComponentMapper: undefined,
             scrollParentSelector: undefined,
-            onLineClick: undefined,
-            style: require('./style')
+            onLineClick: undefined
         };
     },
     /**


### PR DESCRIPTION
## [Advanced Search] Fix the component

### Description

Resolve a little issue which couldn't make the showcase work.

### Patch

The showcase couldn't be launched with the line we have deleted in this fix.
Webpack couldn't find the require. It was a mistake.

