### PR TITLE
[Checkbox] Improve checkbox rendering

### DIFF
--- a/src/components/input/checkbox/example/index.jsx
+++ b/src/components/input/checkbox/example/index.jsx
@@ -5,6 +5,7 @@ const {Component} = React;
 // Components
 
 const {Checkbox} = FocusComponents.components.input;
+const {CheckboxWithError} = FocusComponents.components.input;
 
 class InputCheckboxSample extends Component {
     /**
@@ -16,7 +17,17 @@ class InputCheckboxSample extends Component {
     }
 
     state = {
-        controllableCheckbox: true
+        controllableCheckbox: true,
+        standardCheckbox: true,
+        valueCheckbox: true,
+        withErrorCheckbox: false,
+        withoutLabelCheckbox: true
+    }
+
+    onChangeInput(name) {
+        return value => {
+            this.setState({[name]: value});
+        };
     }
 
     /**
@@ -24,26 +35,30 @@ class InputCheckboxSample extends Component {
     * @return {object} React node
     */
     render() {
-        const {controllableCheckbox} = this.state;
+        const {controllableCheckbox, standardCheckbox, valueCheckbox, withErrorCheckbox, withoutLabelCheckbox} = this.state;
+        const error = withErrorCheckbox ? null : 'To proceed, you must agree with the terms and conditions of the License Agreement.';
         return (
             <div>
-                <h1>Input checkbox</h1>
                 <h3>Standard checkbox</h3>
-                <Checkbox label='My awsome checkbox' value={true}/>
+                <Checkbox label='My awsome checkbox' value={standardCheckbox} onChange={this.onChangeInput('standardCheckbox')} />
 
                 <h3>Controllable checkbox</h3>
-                <Checkbox label='My awsome checkbox' value={controllableCheckbox} />
+                <Checkbox label='My awsome checkbox' value={controllableCheckbox} onChange={this.onChangeInput('controllableCheckbox')} />
                 <button className='mdl-button mdl-js-button mdl-button--raised mdl-button--colored' onClick={() => {this.setState({controllableCheckbox: !controllableCheckbox})}}>
                     Toggle the checkbox value
                 </button>
+
                 <h3>Without label</h3>
-                <Checkbox value={true} />
+                <Checkbox value={withoutLabelCheckbox} onChange={this.onChangeInput('withoutLabelCheckbox')} />
 
                 <h3>Get Checkbox value</h3>
-                <Checkbox label='My awsome checkbox' ref='cbTestGetValue' value={true}/>
+                <Checkbox label='My awsome checkbox' ref='cbTestGetValue' value={valueCheckbox} onChange={this.onChangeInput('valueCheckbox')} />
                 <button className='mdl-button mdl-js-button mdl-button--raised mdl-button--colored' onClick={this.handleGetValueClick}>
                     Get the checkbox value
                 </button>
+
+                <h3>Display Checkbox with an error</h3>
+                <CheckboxWithError label='I have read and accepted the Terms and Conditions and Risk' value={withErrorCheckbox} onChange={this.onChangeInput('withErrorCheckbox')} error={error} />
             </div>
         );
     }

--- a/src/components/input/checkbox/index.js
+++ b/src/components/input/checkbox/index.js
@@ -38,16 +38,12 @@ class InputCheckBox extends Component {
     }
 
     render() {
-        const {label, value, error} = this.props;
+        const {label, value} = this.props;
         return (
-          <div
-              data-error={!!error}
-              data-focus='input-checkbox-container'
-          >
+          <div data-focus='input-checkbox-container'>
             <label className={`mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect`} data-focus='input-checkbox' ref='mdlHolder'>
                 <input checked={value} className='mdl-checkbox__input' onChange={::this.handleOnChange} ref='checkbox' type='checkbox'/>
                 {label && <span className='mdl-checkbox__label'>{this.i18n(label)}</span>}
-                {error && <span className='mdl-checkbox__error'>{this.i18n(error)}</span>}
             </label>
           </div>
         );

--- a/src/components/input/checkbox/style/checkbox.scss
+++ b/src/components/input/checkbox/style/checkbox.scss
@@ -1,26 +1,25 @@
+$checkobox-with-error-color: #de3226;
+
 // Gestion CSS de l'erreur sur les checkboxs
-[data-focus="input-checkbox-container"] {
-  .mdl-checkbox {
-    padding-bottom: 20px;
-    height:100%;
-    margin:7px 0;
-  }
-
-  .mdl-checkbox__error {
-      color: rgb(222, 50, 38);
-      position: absolute;
-      font-size: 12px;
-      margin-top: 3px;
-      visibility: hidden;
-      display: block;
-  }
-}
-
-[data-focus="input-checkbox-container"][data-error="true"] {
-    .mdl-checkbox {
-      color: #de3226;
-      .mdl-checkbox__error{
-        visibility: visible;
-      }
+[data-focus="input-checkbox-with-error-container"] {
+    [data-focus="input-checkbox"] {
+        height: auto;
+    }
+    .input-checkbox__error {
+        color: $checkobox-with-error-color;
+        font-size: 12px;
+        display: block;
+    }
+    &[data-error="true"] {
+        .mdl-checkbox {
+            &.is-checked {
+                .mdl-checkbox__tick-outline {
+                    background-color: $checkobox-with-error-color;
+                }
+            }
+        }
+        .mdl-checkbox__box-outline {
+            border-color: $checkobox-with-error-color;
+        }
     }
 }

--- a/src/components/input/checkbox/with-error.js
+++ b/src/components/input/checkbox/with-error.js
@@ -1,0 +1,56 @@
+import React, {Component, PropTypes} from 'react';
+import ReactDOM from 'react-dom';
+import Translation from '../../../behaviours/translation';
+import Material from '../../../behaviours/material';
+
+const propTypes = {
+    label: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    value: PropTypes.bool.isRequired,
+    error: PropTypes.string
+};
+
+const defaultProps = {
+    value: false
+};
+
+@Translation
+@Material('mdlHolder')
+class InputCheckBoxWithError extends Component {
+    getValue = () => {
+        const domElement = ReactDOM.findDOMNode(this.refs.checkbox);
+        return domElement.checked;
+    };
+
+    componentDidUpdate() {
+        const {value} = this.props;
+        const method = value ? 'add' : 'remove';
+        const node = ReactDOM.findDOMNode(this.refs.mdlHolder);
+        if (node) {
+            node.classList[method]('is-checked');
+        }
+    }
+
+    handleOnChange({target: {checked}}) {
+        const {onChange} = this.props;
+        onChange(checked);
+    }
+
+    render() {
+        const {label, value, error} = this.props;
+        return (
+            <div data-error={!!error} data-focus='input-checkbox-with-error-container'>
+                <label className={`mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect`} data-focus='input-checkbox' ref='mdlHolder'>
+                    <input checked={value} className='mdl-checkbox__input' onChange={::this.handleOnChange} ref='checkbox' type='checkbox'/>
+                    {label && <span className='mdl-checkbox__label'>{this.i18n(label)}</span>}
+                    {error && <span className='input-checkbox__error'>{this.i18n(error)}</span>}
+                </label>
+            </div>
+        );
+    }
+}
+
+InputCheckBoxWithError.displayName = 'InputCheckBoxWithError';
+InputCheckBoxWithError.propTypes = propTypes;
+InputCheckBoxWithError.defaultProps = defaultProps;
+export default InputCheckBoxWithError;

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -1,17 +1,19 @@
-import date from './date';
-import text from './text';
-import textarea from './textarea';
-import checkbox from './checkbox';
-import toggle from './toggle';
-import select from './select';
 import AutocompleteSelect from './autocomplete-select/field';
+import Checkbox from './checkbox';
+import CheckboxWithError from './checkbox/with-error';
+import Date from './date';
+import Select from './select';
+import Text from './text';
+import Textarea from './textarea';
+import Toggle from './toggle';
 
 export default {
-    Checkbox: checkbox,
-    Date: date,
-    Text: text,
-    Toggle: toggle,
-    Select: select,
-    Textarea: textarea,
-    AutocompleteSelect
+    AutocompleteSelect,
+    Checkbox,
+    CheckboxWithError,
+    Date,
+    Select,
+    Text,
+    Toggle,
+    Textarea
 };


### PR DESCRIPTION
## Description

Last commit on checkbox add a new feature : the possibility to define an error.
This new feature added  some problems too with checkbox used in List to select data : the rendering was not good.

As a checkbox handle a boolean value, his behaviour should be pure. Used in a form, it should never raised a error due to his value.

But some projects need a checkbox on which it is necessary to associate an error, to validate Terms for example : 

![image](https://cloud.githubusercontent.com/assets/5349745/13395638/53614afe-def0-11e5-8704-4469da1402be.png)

So, we decided to separate the checkbox used in a form with the one that displays an error.

It also correct the rendering of checkbox displayed in Lists to select a row. It is now correctly aligned in the middle of the line.
