### PR TITLE
[Advanced search] add default group component

### DIFF
--- a/src/page/search/advanced-search/group.js
+++ b/src/page/search/advanced-search/group.js
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import Translation from '../../../behaviours/translation';
+import formatter from  'focus-core/definition/formatter/number';
 
 //web components
 import {component as Button} from '../../../common/button/action';
@@ -8,7 +9,6 @@ import Grid from '../../../common/grid';
 
 const propTypes = {
     canShowMore: PropTypes.bool.isRequired,
-    children: PropTypes.array.isRequired,
     count: PropTypes.number.isRequired,
     groupKey: PropTypes.string.isRequired,
     showAllHandler: PropTypes.func.isRequired,
@@ -24,12 +24,11 @@ class AdvancedSearchGroup extends Component {
 
     render() {
         const {canShowMore, count, children, groupKey, showAllHandler, showMoreHandler} = this.props;
-        const traductionGroupKey = `search.group.${groupKey.toLowerCase()}`;
         return (
             <div data-focus='group-container'>
                 <h3>
-                    <span>{this.i18n(traductionGroupKey)}</span>
-                    <span>{count}</span>
+                    <span>{groupKey}</span>
+                    <span>{formatter.format(count)}</span>
                 </h3>
                 <p>{this.i18n('search.mostRelevant')}</p>
                 <div data-focus="group-container-results">

--- a/src/page/search/advanced-search/group.js
+++ b/src/page/search/advanced-search/group.js
@@ -1,0 +1,57 @@
+import React, {Component, PropTypes} from 'react';
+import Translation from '../../../behaviours/translation';
+
+//web components
+import {component as Button} from '../../../common/button/action';
+import Column from '../../../common/column';
+import Grid from '../../../common/grid';
+
+const propTypes = {
+    canShowMore: PropTypes.bool.isRequired,
+    children: PropTypes.array.isRequired,
+    count: PropTypes.number.isRequired,
+    groupKey: PropTypes.string.isRequired,
+    showAllHandler: PropTypes.func.isRequired,
+    showMoreHandler: PropTypes.func.isRequired
+};
+
+const defaultProps = {
+    count: 0
+};
+
+@Translation
+class AdvancedSearchGroup extends Component {
+
+    render() {
+        const {canShowMore, count, children, groupKey, showAllHandler, showMoreHandler} = this.props;
+        const traductionGroupKey = `search.group.${groupKey.toLowerCase()}`;
+        return (
+            <div data-focus='group-container'>
+                <h3>
+                    <span>{this.i18n(traductionGroupKey)}</span>
+                    <span>{count}</span>
+                </h3>
+                <p>{this.i18n('search.mostRelevant')}</p>
+                <div data-focus="group-container-results">
+                    {children}
+                </div>
+                <div data-focus='group-container-actions'>
+                    <div data-focus='group-container-actions__left'>
+                        {canShowMore &&
+                            <Button handleOnClick={showMoreHandler} label={this.i18n('search.show.more')} />
+                        }
+                    </div>
+                    <div data-focus='group-container-actions__right'>
+                        <Button shape={null} color='accent' handleOnClick={() => {showAllHandler(groupKey);}} label={this.i18n('search.show.all')} />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+AdvancedSearchGroup.propTypes = propTypes;
+AdvancedSearchGroup.defaultProps = defaultProps;
+AdvancedSearchGroup.displayName = 'AdvancedSearchGroup';
+
+export default AdvancedSearchGroup;

--- a/src/page/search/advanced-search/index.js
+++ b/src/page/search/advanced-search/index.js
@@ -8,25 +8,21 @@ const {isFunction} = require('lodash/lang');
 const {reduce} = require('lodash/collection');
 
 // Components
-
 const FacetBox = require('./facet-box').component;
 const ListActionBar = require('./action-bar').component;
 const ListSummary = require('./list-summary').component;
 const Results = require('../common/component/results').component;
-
 const BackToTopComponent = require('../../../common/button/back-to-top').component;
+import DefaultGroupComponent from './group';
 
 // Store
-
 import {advancedSearchStore} from 'focus-core/search/built-in-store';
 
 // Mixins
-
 const CartridgeBehaviour = require('../../mixin/cartridge-behaviour');
 import type from 'focus-core/component/types';
 
 // Actions
-
 import actionBuilder from 'focus-core/search/action-builder';
 
 /**
@@ -49,21 +45,21 @@ const AdvancedSearch = {
     */
     getDefaultProps() {
         return {
-            facetConfig: {},
-            scopesConfig: {},
-            isSelection: true,
-            hasBackToTop: true,
-            backToTopComponent: BackToTopComponent,
-            store: advancedSearchStore,
             action: undefined,
-            service: undefined,
-            orderableColumnList: [],
+            backToTopComponent: BackToTopComponent,
+            facetConfig: {},
+            groupComponent: DefaultGroupComponent,
+            hasBackToTop: true,
+            isSelection: true,
             lineOperationList: [],
-            openedFacetList: {},
-            groupComponent: undefined,
             lineComponentMapper: undefined,
+            orderableColumnList: [],
+            onLineClick: undefined,
+            openedFacetList: {},
+            scopesConfig: {},
             scrollParentSelector: undefined,
-            onLineClick: undefined
+            service: undefined,
+            store: advancedSearchStore
         };
     },
     /**
@@ -71,22 +67,22 @@ const AdvancedSearch = {
     * @type {Object}
     */
     propTypes: {
-        scopesConfig: type('object'),
-        facetConfig: type('object'),
-        isSelection: type('bool'),
-        hasBackToTop: type('bool'),
-        backToTopComponent: type('func'),
-        store: type('object'),
         action: type('object'),
-        service: type('object'),
-        openedFacetList: type('object'),
-        orderableColumnList: type(['array', 'object']),
-        lineOperationList: type(['array', 'object']),
+        backToTopComponent: type('func'),
         exportAction: type('func'),
+        facetConfig: type('object'),
         groupComponent: type('func'),
+        hasBackToTop: type('bool'),
+        isSelection: type('bool'),
         lineComponentMapper: type('func'),
+        lineOperationList: type(['array', 'object']),
+        onLineClick: type('func'),
+        orderableColumnList: type(['array', 'object']),
+        openedFacetList: type('object'),
+        scopesConfig: type('object'),
         scrollParentSelector: type('string'),
-        onLineClick: type('func')
+        service: type('object'),
+        store: type('object')
     },
     /**
      * Get initial state

--- a/src/page/search/advanced-search/style/advanced-search.scss
+++ b/src/page/search/advanced-search/style/advanced-search.scss
@@ -1,11 +1,41 @@
-[data-focus='advanced-search'] {
-   [data-focus='facet-container'] {
-     float: left;
-   }
 
-   [data-focus='result-container'] {
-     padding-left: 30px;
-     display: table-cell;
-     width: 5000px;
-   }
+
+[data-focus='advanced-search'] {
+    [data-focus='facet-container'] {
+        float: left;
+    }
+
+    [data-focus='result-container'] {
+        display: table-cell;
+        padding-left: 30px;
+        width: 5000px;
+
+        [data-focus="group-container"] {
+            margin: 30px 0;
+            h3 {
+                font-size: 28px;
+                margin: 0;
+                line-height: 30px;
+                span:nth-child(2) {
+                    margin-left: 15px;
+                    font-size: 18px;
+                    font-weight: bold;
+                }
+            }
+            & > p {
+                margin-bottom: 8px;
+            }
+            [data-focus="group-container-results"] {
+
+            }
+            [data-focus="group-container-actions"] {
+                display: flex;
+                padding: 10 0;
+                & > div {
+                    width: 50%;
+                    text-align: right;
+                }
+            }
+        }
+    }
 }

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -147,9 +147,11 @@ const Results = {
             selectionResultsMap,
             ...otherProps
         } = this.props;
-        let selectionData = selectionResultsMap ? selectionResultsMap[key] || [] : [];
-        let LineComponent = lineComponentMapper(key, list);
-        let hasMoreData = isUnique !== undefined && isUnique && list.length < count;
+        const selectionData = selectionResultsMap ? selectionResultsMap[key] || [] : [];
+        const scope = otherProps.store.getScope();
+        const lineKey = scope === undefined || scope === 'ALL' ? key : scope;
+        const LineComponent = lineComponentMapper(lineKey, list);
+        const hasMoreData = isUnique !== undefined && isUnique && list.length < count;
         return (
             <div>
                 <ListSelection


### PR DESCRIPTION
## Description

Focus did not provide a default group component in advanced search.
Now it does ! You don't have to code one yourself.

![image](https://cloud.githubusercontent.com/assets/5349745/13403961/ced512ac-df17-11e5-80f8-2aabc080a4bc.png)
