### PR TITLE
Add possibility to set ErrorCenter property as `null` to disable it.

### DIFF
--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -18,7 +18,7 @@ const defaultProps = {
     LoadingStatusBar: LoadingStatusBarDefault,
     MessageCenter: MessageCenterDefault, // default message center
     ConfirmWrapper: ConfirmWrapperDefault, // default confirm wrapper,
-    errorCenterDisplay: true // ErrorCenter displayed by default.
+    displayErrorCenter: true // ErrorCenter displayed by default.
 };
 
 // component props definition.
@@ -31,7 +31,7 @@ const propTypes = {
     MenuLeft: PropTypes.func,
     MessageCenter: PropTypes.func,
     LoadingStatusBar: PropTypes.func,
-    errorCenterDisplay: PropTypes.bool
+    displayErrorCenter: PropTypes.bool
 };
 
 /**
@@ -41,13 +41,13 @@ class Layout extends Component {
 
     /** @inheritDoc */
     render() {
-        const {AppHeader, children, ConfirmWrapper, ErrorCenter, Footer, LoadingBar, MenuLeft, MessageCenter, LoadingStatusBar, errorCenterDisplay, ...otherProps} = this.props;
+        const {AppHeader, children, ConfirmWrapper, ErrorCenter, Footer, LoadingBar, MenuLeft, MessageCenter, LoadingStatusBar, displayErrorCenter, ...otherProps} = this.props;
         const menuType = MenuLeft ? 'left' : 'other';
         return (
             <div data-focus='layout' data-menu={menuType} {...otherProps}>
                 <LoadingBar />
                 <MessageCenter />
-                {errorCenterDisplay && 
+                {displayErrorCenter && 
                     <ErrorCenter />
                 }
                 <ConfirmWrapper />

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -17,8 +17,7 @@ const defaultProps = {
     LoadingBar: LoadingBarDefault, // default loading bar
     LoadingStatusBar: LoadingStatusBarDefault,
     MessageCenter: MessageCenterDefault, // default message center
-    ConfirmWrapper: ConfirmWrapperDefault, // default confirm wrapper,
-    displayErrorCenter: true // ErrorCenter displayed by default.
+    ConfirmWrapper: ConfirmWrapperDefault // default confirm wrapper,
 };
 
 // component props definition.
@@ -30,8 +29,7 @@ const propTypes = {
     LoadingBar: PropTypes.func,
     MenuLeft: PropTypes.func,
     MessageCenter: PropTypes.func,
-    LoadingStatusBar: PropTypes.func,
-    displayErrorCenter: PropTypes.bool
+    LoadingStatusBar: PropTypes.func
 };
 
 /**
@@ -41,13 +39,13 @@ class Layout extends Component {
 
     /** @inheritDoc */
     render() {
-        const {AppHeader, children, ConfirmWrapper, ErrorCenter, Footer, LoadingBar, MenuLeft, MessageCenter, LoadingStatusBar, displayErrorCenter, ...otherProps} = this.props;
+        const {AppHeader, children, ConfirmWrapper, ErrorCenter, Footer, LoadingBar, MenuLeft, MessageCenter, LoadingStatusBar, ...otherProps} = this.props;
         const menuType = MenuLeft ? 'left' : 'other';
         return (
             <div data-focus='layout' data-menu={menuType} {...otherProps}>
                 <LoadingBar />
                 <MessageCenter />
-                {displayErrorCenter && 
+                {ErrorCenter && 
                     <ErrorCenter />
                 }
                 <ConfirmWrapper />

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -17,7 +17,8 @@ const defaultProps = {
     LoadingBar: LoadingBarDefault, // default loading bar
     LoadingStatusBar: LoadingStatusBarDefault,
     MessageCenter: MessageCenterDefault, // default message center
-    ConfirmWrapper: ConfirmWrapperDefault // default confirm wrapper,
+    ConfirmWrapper: ConfirmWrapperDefault, // default confirm wrapper,
+    errorCenterDisplay: true // ErrorCenter displayed by default.
 };
 
 // component props definition.
@@ -29,7 +30,8 @@ const propTypes = {
     LoadingBar: PropTypes.func,
     MenuLeft: PropTypes.func,
     MessageCenter: PropTypes.func,
-    LoadingStatusBar: PropTypes.func
+    LoadingStatusBar: PropTypes.func,
+    errorCenterDisplay: PropTypes.bool
 };
 
 /**
@@ -39,13 +41,15 @@ class Layout extends Component {
 
     /** @inheritDoc */
     render() {
-        const {AppHeader, children, ConfirmWrapper, ErrorCenter, Footer, LoadingBar, MenuLeft, MessageCenter, LoadingStatusBar, ...otherProps} = this.props;
+        const {AppHeader, children, ConfirmWrapper, ErrorCenter, Footer, LoadingBar, MenuLeft, MessageCenter, LoadingStatusBar, errorCenterDisplay, ...otherProps} = this.props;
         const menuType = MenuLeft ? 'left' : 'other';
         return (
             <div data-focus='layout' data-menu={menuType} {...otherProps}>
                 <LoadingBar />
                 <MessageCenter />
-                <ErrorCenter />
+                {errorCenterDisplay && 
+                    <ErrorCenter />
+                }
                 <ConfirmWrapper />
                 <AppHeader />
                 {MenuLeft &&


### PR DESCRIPTION
## [Layout] Add possibility to set ErrorCenter property as `null` to disable it.

### Description

Set ErrorCenter property to `null` to disable ErrorCenter component.

### Example

```jsx
const ErrorCenter = () => (null);

render(Layout, 'div#spabody', {
    props: {MenuLeft: MenuLeft, ErrorCenter: ErrorCenter}
});
```
