### PR TITLE
Remove z-index in scrolling header

### DIFF
--- a/src/components/layout/style/header-scrolling.scss
+++ b/src/components/layout/style/header-scrolling.scss
@@ -47,8 +47,6 @@ to { height: auto; }
 
     // When the header is deployed, don't show the summary.
     &[data-deployed="true"] {
-        z-index: $header-top-row-zindex;
-
         div[data-focus="header-top-row"] {
             div[data-focus="header-top-row-middle"] {
                 display: none;


### PR DESCRIPTION
## [Header] z-index set

### Description

In the scrolling header, a z-index is set.

### Patch

Remove it.
> Fixes #906

