### PR TITLE
add role declaration in index.js

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,6 +10,7 @@ import panel from './panel';
 import scrollspyContainer from './scrollspy-container';
 import Confirm from './confirm';
 import IconDropdown from './icon-dropdown';
+import role from './role';
 
 export default {
     HeaderActions: headerActions,
@@ -23,5 +24,6 @@ export default {
     MenuLeft: menuLeft,
     Panel: panel,
     ScrollspyContainer: scrollspyContainer,
-    IconDropdown
+    IconDropdown,
+    Role: role,
 }


### PR DESCRIPTION
##  ROLE fix
### Description
Role component was not declared in index.js

### Patch [in case of a fix]

Component role added in index.js

### Example [in case of a new feature]

```jsx

import role from './role';


export default {
   .......
    Role: role,
 }

```
