### PR TITLE
Fix #1056

### DIFF
--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -331,7 +331,7 @@ const Results = {
             return (
                 <div data-focus='search-results'>
                 {
-                    map(resultsList, (resultGroup) => {
+                    map(resultsMap, (resultGroup) => {
                         const key = keys(resultGroup)[0]; //group property name
                         const list = resultGroup[key];
                         const count = groupCounts[key];

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -9,6 +9,7 @@ const clone = require('lodash/lang/clone');
 const filter = require('lodash/collection/filter');
 const find = require('lodash/collection/find');
 const keys = require('lodash/object/keys');
+const isArray = require('lodash/lang/isArray');
 const map = require('lodash/collection/map');
 const mapValues = require('lodash/object/mapValues');
 const omit = require('lodash/object/omit');
@@ -255,10 +256,17 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        if (resultsMap && 1 === resultsMap.length) {
-            // here : juste a single list
+        
+        // resultMap can be either an Array or an Object depending of the search being grouped or not.
+        if (resultsMap && isArray(resultsMap) && 1 === resultsMap.length) {
             return {
                 [resultsMap[0][0]]: {
+                    count: this.props.totalCount
+                }
+            };
+        } else if (1 === keys(resultsMap).length) {
+            return {
+                [keys(resultsMap)[0]]: {
                     count: this.props.totalCount
                 }
             };
@@ -288,20 +296,35 @@ const Results = {
             return this._renderEmptyResults();
         }
 
-        // Filter groups with no results
-        const resultsList = filter(this.props.resultsMap, (resultGroup) => {
-            const propertyGroupName = keys(resultGroup)[0]; //group property name
-            const list = resultGroup[propertyGroupName];
-            return 0 !== list.length;
-        });
+        let resultsMap;
+
+        // resultsMap can be an Array or an Object.
+        if (isArray(this.props.resultsMap)) {
+            resultsMap = filter(this.props.resultsMap, function (resultGroup) {
+                const propertyGroupName = keys(resultGroup)[0]; //group property name
+                const list = resultGroup[propertyGroupName];
+                return 0 !== list.length;
+            });
+        } else {
+            resultsMap = omit(this.props.resultsMap, function (resultGroup) {
+                const propertyGroupName = keys(resultGroup)[0]; //group property name
+                const list = resultGroup[propertyGroupName];
+                return 0 === list.length;
+            });
+        }
 
         // Get the count for each group
         const groupCounts = this._getGroupCounts();
         // Check if there is only one group left
 
-        if (1 === resultsList.length) {
-            const key = keys(resultsList[0])[0];
-            const list = resultsList[0][key];
+        if (isArray(resultsMap) && 1 === resultsMap.length) {
+            const key = keys(resultsMap[0])[0];
+            const list = resultsMap[0][key];
+            const count = groupCounts[key].count;
+            return this._renderSingleGroup(list, key, count, true);
+        } else if (1 === keys(resultsMap).length) {
+            const key = keys(resultsMap)[0];
+            const list = resultsMap[key];
             const count = groupCounts[key].count;
             return this._renderSingleGroup(list, key, count, true);
         } else {

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -255,7 +255,7 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        if (1 === resultsMap.length) {
+        if (resultsMap && 1 === resultsMap.length) {
             // here : juste a single list
             return {
                 [resultsMap[0][0]]: {
@@ -292,7 +292,7 @@ const Results = {
         const resultsList = filter(this.props.resultsMap, (resultGroup) => {
             const propertyGroupName = keys(resultGroup)[0]; //group property name
             const list = resultGroup[propertyGroupName];
-            return 0 === list.length;
+            return 0 !== list.length;
         });
 
         // Get the count for each group
@@ -301,7 +301,7 @@ const Results = {
 
         if (1 === resultsList.length) {
             const key = keys(resultsList[0])[0];
-            const list = resultList[0][key];
+            const list = resultsList[0][key];
             const count = groupCounts[key].count;
             return this._renderSingleGroup(list, key, count, true);
         } else {

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -6,6 +6,7 @@ import builder from 'focus-core/component/builder';
 
 const assign = require('lodash/object/assign');
 const clone = require('lodash/lang/clone');
+const filter = require('lodash/collection/filter');
 const find = require('lodash/collection/find');
 const keys = require('lodash/object/keys');
 const map = require('lodash/collection/map');
@@ -254,11 +255,10 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        const groupKeys = keys(resultsMap);
-        if (1 === groupKeys.length) {
+        if (1 === resultsMap.length) {
             // here : juste a single list
             return {
-                [groupKeys[0]]: {
+                [resultsMap[0][0]]: {
                     count: this.props.totalCount
                 }
             };
@@ -289,7 +289,7 @@ const Results = {
         }
 
         // Filter groups with no results
-        const resultsMap = omit(this.props.resultsMap, (resultGroup) => {
+        const resultsList = filter(this.props.resultsMap, (resultGroup) => {
             const propertyGroupName = keys(resultGroup)[0]; //group property name
             const list = resultGroup[propertyGroupName];
             return 0 === list.length;
@@ -299,16 +299,16 @@ const Results = {
         const groupCounts = this._getGroupCounts();
         // Check if there is only one group left
 
-        if (1 === keys(resultsMap).length) {
-            const key = keys(resultsMap)[0];
-            const list = resultsMap[key];
+        if (1 === resultsList.length) {
+            const key = keys(resultsList[0])[0];
+            const list = resultList[0][key];
             const count = groupCounts[key].count;
             return this._renderSingleGroup(list, key, count, true);
         } else {
             return (
                 <div data-focus='search-results'>
                 {
-                    map(resultsMap, (resultGroup) => {
+                    map(resultsList, (resultGroup) => {
                         const key = keys(resultGroup)[0]; //group property name
                         const list = resultGroup[key];
                         const count = groupCounts[key];


### PR DESCRIPTION
There #1056.

My ElasticSearch VM is dead tonight so I haven't been able to test it, so I've just done this right here in my browser, with my head and a paper.

I believe it's right though. The problem was that the `results` component didn't receive an update with the new search API that wraps groups (and facets) in a list to keep the order. Multiple groups kept working because #YOLOJavascript, but single group failed.

I hope my VM crawls back to life during the night so I can test it for real tomorrow morning.


(if you ever merge this, I'd be glad if it doesn't get reverted at the last minute before the next release, it is somewhat critical this time)