### PR TITLE
Hotfix search groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "bundle": "better-npm-run bundle",
     "copy-sass": "better-npm-run copy-sass",
     "build": "node scripts/mdl-variables-copy.js && better-npm-run babelify && better-npm-run copy-sass && better-npm-run bundle",
-    "test": "mocha src/**/__tests__/**/*.js",
-    "test:watch": "mocha src/**/__tests__/**/*.js -w",
+    "test": "BABEL_ENV=production mocha src/**/__tests__/**/*.js",
+    "test:watch": "BABEL_ENV=production mocha src/**/__tests__/**/*.js -w",
     "postinstall": "node scripts/mdl-variables-copy.js",
     "profile": "better-npm-run profile",
     "fix-lint": "eslint --fix src/** || exit 0"
@@ -44,21 +44,7 @@
   },
   "babel": {
     "presets": [
-      "stage-0",
-      "react",
-      "es2015"
-    ],
-    "plugins": [
-      "transform-class-properties",
-      "transform-decorators-legacy",
-      "add-module-exports",
-      "transform-proto-to-assign",
-      [
-        "transform-es2015-classes",
-        {
-          "loose": true
-        }
-      ]
+      "focus"
     ]
   },
   "repository": {
@@ -92,15 +78,7 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "4.1.3",
     "babel-loader": "^6.2.1",
-    "babel-plugin-add-module-exports": "^0.1.2",
-    "babel-plugin-runtime": "^1.0.7",
-    "babel-plugin-transform-class-properties": "^6.4.0",
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-es2015-classes": "^6.5.2",
-    "babel-plugin-transform-proto-to-assign": "^6.5.0",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-react": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
+    "babel-preset-focus": "^0.5.2",
     "babel-runtime": "^6.3.19",
     "better-npm-run": "0.0.5",
     "chai": "^3.2.0",

--- a/scripts/babelify.js
+++ b/scripts/babelify.js
@@ -4,17 +4,7 @@ var babel = require('babel-core');
 
 var babelOptions = {
     "presets": [
-        "es2015",
-        "stage-0",
-        "react"
-    ],
-    "plugins": [
-        "add-module-exports",
-        "transform-class-properties",
-        "transform-decorators-legacy",
-        "transform-proto-to-assign",
-        ["transform-es2015-classes", {"loose": true}]
-
+        "focus"
     ],
     sourceMaps: 'inline'
 };

--- a/src/behaviours/material/__tests__/index.js
+++ b/src/behaviours/material/__tests__/index.js
@@ -1,6 +1,6 @@
 import MaterialBehaviour from '../';
 
-describe.skip('The Material behaviour', () => {
+describe('The Material behaviour', () => {
     let mdlSpy;
     before(() => {
         mdlSpy = global.componentHandler = {

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -331,7 +331,7 @@ const Results = {
             return (
                 <div data-focus='search-results'>
                 {
-                    map(resultsList, (resultGroup) => {
+                    map(resultsMap, (resultGroup) => {
                         const key = keys(resultGroup)[0]; //group property name
                         const list = resultGroup[key];
                         const count = groupCounts[key];

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -9,6 +9,7 @@ const clone = require('lodash/lang/clone');
 const filter = require('lodash/collection/filter');
 const find = require('lodash/collection/find');
 const keys = require('lodash/object/keys');
+const isArray = require('lodash/lang/isArray');
 const map = require('lodash/collection/map');
 const mapValues = require('lodash/object/mapValues');
 const omit = require('lodash/object/omit');
@@ -255,10 +256,17 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        if (resultsMap && 1 === resultsMap.length) {
-            // here : juste a single list
+        
+        // resultMap can be either an Array or an Object depending of the search being grouped or not.
+        if (resultsMap && isArray(resultsMap) && 1 === resultsMap.length) {
             return {
                 [resultsMap[0][0]]: {
+                    count: this.props.totalCount
+                }
+            };
+        } else if (1 === keys(resultsMap).length) {
+            return {
+                [keys(resultsMap)[0]]: {
                     count: this.props.totalCount
                 }
             };
@@ -288,20 +296,35 @@ const Results = {
             return this._renderEmptyResults();
         }
 
-        // Filter groups with no results
-        const resultsList = filter(this.props.resultsMap, (resultGroup) => {
-            const propertyGroupName = keys(resultGroup)[0]; //group property name
-            const list = resultGroup[propertyGroupName];
-            return 0 !== list.length;
-        });
+        let resultsMap;
+
+        // resultsMap can be an Array or an Object.
+        if (isArray(this.props.resultsMap)) {
+            resultsMap = filter(this.props.resultsMap, function (resultGroup) {
+                const propertyGroupName = keys(resultGroup)[0]; //group property name
+                const list = resultGroup[propertyGroupName];
+                return 0 !== list.length;
+            });
+        } else {
+            resultsMap = omit(this.props.resultsMap, function (resultGroup) {
+                const propertyGroupName = keys(resultGroup)[0]; //group property name
+                const list = resultGroup[propertyGroupName];
+                return 0 === list.length;
+            });
+        }
 
         // Get the count for each group
         const groupCounts = this._getGroupCounts();
         // Check if there is only one group left
 
-        if (1 === resultsList.length) {
-            const key = keys(resultsList[0])[0];
-            const list = resultsList[0][key];
+        if (isArray(resultsMap) && 1 === resultsMap.length) {
+            const key = keys(resultsMap[0])[0];
+            const list = resultsMap[0][key];
+            const count = groupCounts[key].count;
+            return this._renderSingleGroup(list, key, count, true);
+        } else if (1 === keys(resultsMap).length) {
+            const key = keys(resultsMap)[0];
+            const list = resultsMap[key];
             const count = groupCounts[key].count;
             return this._renderSingleGroup(list, key, count, true);
         } else {

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -255,7 +255,7 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        if (1 === resultsMap.length) {
+        if (resultsMap && 1 === resultsMap.length) {
             // here : juste a single list
             return {
                 [resultsMap[0][0]]: {
@@ -292,7 +292,7 @@ const Results = {
         const resultsList = filter(this.props.resultsMap, (resultGroup) => {
             const propertyGroupName = keys(resultGroup)[0]; //group property name
             const list = resultGroup[propertyGroupName];
-            return 0 === list.length;
+            return 0 !== list.length;
         });
 
         // Get the count for each group
@@ -301,7 +301,7 @@ const Results = {
 
         if (1 === resultsList.length) {
             const key = keys(resultsList[0])[0];
-            const list = resultList[0][key];
+            const list = resultsList[0][key];
             const count = groupCounts[key].count;
             return this._renderSingleGroup(list, key, count, true);
         } else {

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -6,6 +6,7 @@ import builder from 'focus-core/component/builder';
 
 const assign = require('lodash/object/assign');
 const clone = require('lodash/lang/clone');
+const filter = require('lodash/collection/filter');
 const find = require('lodash/collection/find');
 const keys = require('lodash/object/keys');
 const map = require('lodash/collection/map');
@@ -254,11 +255,10 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        const groupKeys = keys(resultsMap);
-        if (1 === groupKeys.length) {
+        if (1 === resultsMap.length) {
             // here : juste a single list
             return {
-                [groupKeys[0]]: {
+                [resultsMap[0][0]]: {
                     count: this.props.totalCount
                 }
             };
@@ -289,7 +289,7 @@ const Results = {
         }
 
         // Filter groups with no results
-        const resultsMap = omit(this.props.resultsMap, (resultGroup) => {
+        const resultsList = filter(this.props.resultsMap, (resultGroup) => {
             const propertyGroupName = keys(resultGroup)[0]; //group property name
             const list = resultGroup[propertyGroupName];
             return 0 === list.length;
@@ -299,16 +299,16 @@ const Results = {
         const groupCounts = this._getGroupCounts();
         // Check if there is only one group left
 
-        if (1 === keys(resultsMap).length) {
-            const key = keys(resultsMap)[0];
-            const list = resultsMap[key];
+        if (1 === resultsList.length) {
+            const key = keys(resultsList[0])[0];
+            const list = resultList[0][key];
             const count = groupCounts[key].count;
             return this._renderSingleGroup(list, key, count, true);
         } else {
             return (
                 <div data-focus='search-results'>
                 {
-                    map(resultsMap, (resultGroup) => {
+                    map(resultsList, (resultGroup) => {
                         const key = keys(resultGroup)[0]; //group property name
                         const list = resultGroup[key];
                         const count = groupCounts[key];

--- a/src/search/search-bar/__tests__/search-bar-test.js
+++ b/src/search/search-bar/__tests__/search-bar-test.js
@@ -5,7 +5,7 @@ import {quickSearchStore} from 'focus-core/search/built-in-store';
 import actionBuilder from 'focus-core/search/action-builder';
 
 
-describe.only('SearchBar with no scope', () => {
+describe('SearchBar with no scope', () => {
     describe('Check if a default search bar works fine', () => {
         let component;
         before( () => {

--- a/test/mocha-bootload.js
+++ b/test/mocha-bootload.js
@@ -1,13 +1,7 @@
 // Global configuration uese for tests.
 require('babel-core/register')({
     presets: [
-        'stage-0',
-        'react',
-        'es2015'
-    ],
-    plugins: [
-        'transform-class-properties',
-        'transform-decorators-legacy'
+        'focus'
     ]
 });
 


### PR DESCRIPTION
## [Search] Error when single group is returned

### Description

When only one group is returned, the search crashes.

### Patch

Add some defensive code against this crash.
> Fixes #1056 

See [the original pull request](https://github.com/KleeGroup/focus-components/pull/1057) for more details.

### Author

@JabX 