### PR TITLE
FIX 1060: Cartridge in summary mode when scrolled to the top

### DIFF
--- a/src/components/layout/header-scrolling.js
+++ b/src/components/layout/header-scrolling.js
@@ -94,7 +94,7 @@ class HeaderScrolling extends Component {
         }
 
         const {top} = this.scrollPosition();
-        const isDeployed = (canDeploy !== undefined ? canDeploy : this.props.canDeploy) ? top < deployThreshold : false;
+        const isDeployed = (canDeploy !== undefined ? canDeploy : this.props.canDeploy) ? top <= deployThreshold : false;
 
         if (isDeployed !== this.state.isDeployed) {
             this.setState({isDeployed}, this._notifySizeChange);


### PR DESCRIPTION
## [[header-scrolling] FIX: Cartridge in summary mode when scrolled to the top]

### Description

[Description of the issue fixed or the new feature]

### Patch 
The condition wasn't properly computed for a content.clientHeight equals to 60 which result in this case to a deployThresold = 0. In this precise case, we would have to scroll to a negative top position to have the cartridge opened. We just change the condition from 'strict' to 'strict or equal' to deploy the cartridge in that case.

> Fixes #1060 
