### PR TITLE
Fix list actions z-index

### DIFF
--- a/src/list/selection/style/list.scss
+++ b/src/list/selection/style/list.scss
@@ -71,6 +71,7 @@ $boxSize:60px;
             top : 25%;
             right : 0px;
             display: none;
+            z-index: 1;
             .btn {
                 margin-right: 10px;
             }


### PR DESCRIPTION
## [Selection list] Secondary actions are displayed under the next line

### Description

Secondary actions are displayed under the next line.

![](https://cloud.githubusercontent.com/assets/15626856/13570370/39740dba-e46e-11e5-9f3c-136019571851.png)

### Patch

As @gideruette suggested, add a `z-index` to the actions
> Fixes #1006 

![](https://cloud.githubusercontent.com/assets/15626856/13570342/16ea3ba2-e46e-11e5-9af3-0e1ea390b503.png)
