### PR TITLE
Add disable props to checkbox. It fixes #772.

### DIFF
--- a/src/components/input/checkbox/index.js
+++ b/src/components/input/checkbox/index.js
@@ -5,12 +5,14 @@ import Material from '../../../behaviours/material';
 
 const propTypes = {
     label: PropTypes.string,
+    disabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     value: PropTypes.bool.isRequired
 };
 
 const defaultProps = {
-    value: false
+    value: false,
+    disabled: false
 };
 
 const displayName = 'InputCheckBox';
@@ -38,11 +40,11 @@ class InputCheckBox extends Component {
     }
 
     render() {
-        const {label, value} = this.props;
+        const {label, value, disabled} = this.props;
         return (
           <div data-focus='input-checkbox-container'>
             <label className={'mdl-checkbox mdl-js-checkbox mdl-js-ripple-effect'} data-focus='input-checkbox' ref='mdlHolder'>
-                <input checked={value} className='mdl-checkbox__input' onChange={::this.handleOnChange} ref='checkbox' type='checkbox'/>
+                <input checked={value} className='mdl-checkbox__input' disabled={disabled} onChange={::this.handleOnChange} ref='checkbox' type='checkbox'/>
                 {label && <span className='mdl-checkbox__label'>{this.i18n(label)}</span>}
             </label>
           </div>


### PR DESCRIPTION
## Add disable props to checkbox

### Description

Add the `disabled` props to the component. It was missing :-1: 
> Fixes #772 


### Example

```jsx
<Checkbox disabled={true} {...otherprops} />
<Checkbox disabled={false} {...otherprops} />
```

