### PR TITLE
Fix #935

### DIFF
--- a/src/common/form/example/index.jsx
+++ b/src/common/form/example/index.jsx
@@ -85,7 +85,7 @@ const entities = {
         },
         papaCode: {
             domain: 'DO_TEXT',
-            required: true
+            required: false
         },
         age: {
             domain: 'DO_NUMBER',
@@ -97,15 +97,16 @@ const entities = {
             required: false
         },
         bio: {
-            domain: 'DO_EMAIL',
-            InputComponent: FocusComponents.common.input.textarea.component
+            domain: 'DO_TEXT',
+            InputComponent: FocusComponents.components.input.Textarea,
+            DisplayComponent: FocusComponents.components.input.DisplayTextArea
         },
         isCool: {
             domain: 'DO_OUI_NON'
         },
         isNice: {
             domain: 'DO_BOOLEAN',
-            FieldComponent: FocusComponents.common.input.toggle.component
+            FieldComponent: FocusComponents.components.input.Toggle
         },
         birthDate: {
             domain: 'DO_DATE',

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -5,6 +5,7 @@ import Date from './date';
 import Select from './select';
 import Text from './text';
 import Textarea from './textarea';
+import DisplayTextArea from './textarea/consult';
 import Toggle from './toggle';
 
 export default {
@@ -15,5 +16,6 @@ export default {
     Select,
     Text,
     Toggle,
-    Textarea
+    Textarea,
+    DisplayTextArea
 };

--- a/src/components/input/textarea/consult.js
+++ b/src/components/input/textarea/consult.js
@@ -1,0 +1,17 @@
+import React, {Component, PropTypes} from 'react';
+
+const DisplayTextArea = ({value}) => (
+    <div data-focus='display-textarea'>
+        {value}
+    </div>
+);
+
+const propTypes = {
+    value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+    ])
+}
+DisplayTextArea.propTypes = propTypes;
+
+export default DisplayTextArea;

--- a/src/components/input/textarea/style/textarea.scss
+++ b/src/components/input/textarea/style/textarea.scss
@@ -22,3 +22,7 @@
         }
     }
 }
+
+[data-focus='display-textarea'] {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
## [Textarea] Add a display component

### Description

When a value set by the textarea contains multiple lines, the line breaks are not displayed in consult mode.

### Patch

As @durandx suggested, a `white-space: pre-wrap` is added.
> Fixes #935

