### PR TITLE
[ WPI ] Fix global is edit issue #988

### DIFF
--- a/src/application/header/mixin/application-state.js
+++ b/src/application/header/mixin/application-state.js
@@ -24,6 +24,9 @@ var applicationStateMixin = {
     _handleChangeApplicationStatus() {
         this.setState(this._getStateFromStore());
         this.setState({isEdit:(this.state.mode==='edit')});
+        console.log("_handleChangeApplicationStatus", this.state.isEdit);
+        console.log("_handleChangeApplicationStatus", this.props.name, this.state.mode);
+
     },
     _getStateFromStore: function getCartridgeStateFromStore() {
         var processMode = applicationStore.getMode();

--- a/src/application/header/mixin/application-state.js
+++ b/src/application/header/mixin/application-state.js
@@ -24,8 +24,6 @@ var applicationStateMixin = {
     _handleChangeApplicationStatus() {
         this.setState(this._getStateFromStore());
         this.setState({isEdit:(this.state.mode==='edit')});
-        console.log("_handleChangeApplicationStatus", this.state.isEdit);
-        console.log("_handleChangeApplicationStatus", this.props.name, this.state.mode);
     },
     _getStateFromStore: function getCartridgeStateFromStore() {
         var processMode = applicationStore.getMode();

--- a/src/application/header/mixin/application-state.js
+++ b/src/application/header/mixin/application-state.js
@@ -1,30 +1,50 @@
 import applicationStore from 'focus-core/application/built-in-store';
+import application from 'focus-core/application';
+
+const {isUndefined} = require('lodash/lang');
+
 var applicationStateMixin = {
-  /** @inheriteddoc */
+    /** @inheriteddoc */
     getInitialState: function getCartridgeInitialState() {
         return this._getStateFromStore();
     },
-  /** @inheriteddoc */
+    /** @inheriteddoc */
     componentWillMount: function cartridgeWillMount() {
         applicationStore.addModeChangeListener(this._handleChangeApplicationStatus);
         applicationStore.addRouteChangeListener(this._handleChangeApplicationStatus);
     },
-  /** @inheriteddoc */
+    componentWillReceiveProps: function (nextProps) {
+        this._handleChangeMode(this.state.isEdit);
+    },
+    /** @inheriteddoc */
     appStateWillUnMount: function cartridgeWillUnMount() {
         applicationStore.removeModeChangeListener(this._handleChangeApplicationStatus);
         applicationStore.removeRouteChangeListener(this._handleChangeApplicationStatus);
     },
     _handleChangeApplicationStatus() {
         this.setState(this._getStateFromStore());
+        this.setState({isEdit:(this.state.mode==='edit')});
+        console.log("_handleChangeApplicationStatus", this.state.isEdit);
+        console.log("_handleChangeApplicationStatus", this.props.name, this.state.mode);
     },
     _getStateFromStore: function getCartridgeStateFromStore() {
         var processMode = applicationStore.getMode();
         var mode = 'consult';
-        if(processMode && processMode.edit && processMode.edit > 0) {
+        if (processMode && processMode.edit && processMode.edit > 0) {
             mode = 'edit';
         }
         return {mode: mode, route: applicationStore.getRoute()};
-    }
+    },
+    _handleChangeMode(isEdit)
+    {
+        if (!(isUndefined(isEdit))) {
+            if (isEdit) {
+                application.changeMode('edit', null);
+            } else {
+                application.changeMode('consult', null);
+            }
+        }
+    },
 };
 
 module.exports = applicationStateMixin;

--- a/src/application/header/mixin/application-state.js
+++ b/src/application/header/mixin/application-state.js
@@ -26,7 +26,6 @@ var applicationStateMixin = {
         this.setState({isEdit:(this.state.mode==='edit')});
         console.log("_handleChangeApplicationStatus", this.state.isEdit);
         console.log("_handleChangeApplicationStatus", this.props.name, this.state.mode);
-
     },
     _getStateFromStore: function getCartridgeStateFromStore() {
         var processMode = applicationStore.getMode();

--- a/src/application/header/mixin/application-state.js
+++ b/src/application/header/mixin/application-state.js
@@ -10,11 +10,9 @@ var applicationStateMixin = {
     },
     /** @inheriteddoc */
     componentWillMount: function cartridgeWillMount() {
+        this._handleChangeMode(this.state.isEdit);
         applicationStore.addModeChangeListener(this._handleChangeApplicationStatus);
         applicationStore.addRouteChangeListener(this._handleChangeApplicationStatus);
-    },
-    componentWillReceiveProps: function (nextProps) {
-        this._handleChangeMode(this.state.isEdit);
     },
     /** @inheriteddoc */
     appStateWillUnMount: function cartridgeWillUnMount() {
@@ -24,8 +22,8 @@ var applicationStateMixin = {
     _handleChangeApplicationStatus() {
         this.setState(this._getStateFromStore());
         this.setState({isEdit:(this.state.mode==='edit')});
-        console.log("_handleChangeApplicationStatus", this.state.isEdit);
-        console.log("_handleChangeApplicationStatus", this.props.name, this.state.mode);
+        //console.log("_handleChangeApplicationStatus", this.state.isEdit);
+        //console.log("_handleChangeApplicationStatus", this.props.name, this.state.mode);
     },
     _getStateFromStore: function getCartridgeStateFromStore() {
         var processMode = applicationStore.getMode();


### PR DESCRIPTION
## Form  Global attribute isEdit
### Description

Global attribute `isEdit` is not always coherent with the content of the spa

`applicationStateMixin` is listening to isEdit state  and dispatch changeMode regarding to its value 
### Example

``` jsx
const FormExample = React.createClass({

    displayName: 'FormExample',
    mixins: [formMixin, applicationStateMixin],
    definitionPath: 'contact',
    action: action,

    handleOnclick() {
       this.setState({isEdit: !(this.state.isEdit)});
    },
    renderContent()  {
        console.log("renderContent isEdit",this.props.name, this.state.isEdit);
        const style = {display: "block"};
        return (
            <div>
                {this.fieldFor('firstName')}
                <Button handleOnClick={this.handleOnclick}/>
            </div>

        );
    }

});

module.exports = () => (
    <div>
        <FormExample isEdit={false} name='Form1'/>
        <FormExample isEdit={false} name='Form2'/>
        <FormExample isEdit={true}  name='Form3'/>
    </div>
);
```

> it fixes #988 
