### PR TITLE
Fix group counts when grouping changes

### DIFF
--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -111,6 +111,7 @@ const Results = {
                     groupComponent={this.props.groupComponent}
                     groupKey={key}
                     initialRowsCount={initialRowsCount}
+                    key={key}
                     list={list}
                     ref={`group-${key}`}
                     renderResultsList={this._renderResultsList}
@@ -256,7 +257,7 @@ const Results = {
     */
     _getGroupCounts() {
         const {resultsMap} = this.props;
-        
+
         // resultMap can be either an Array or an Object depending of the search being grouped or not.
         if (resultsMap && isArray(resultsMap) && 1 === resultsMap.length) {
             return {


### PR DESCRIPTION
## [Advanced-search] Group retains count when criteria changes
### Description

See #862, @mouffakb explained it very well.

### Patch

Add a `key` to each group, so that React unmounts and mounts new group elements. Their state is initialized correctly this way.
> Fixes #862

