### PR TITLE
[selection list] The Map key is now a `stringified` #820

### DIFF
--- a/src/list/selection/list.js
+++ b/src/list/selection/list.js
@@ -83,7 +83,7 @@ const listMixin = {
         if (selectedItems !== null) {
             const selectedItems = [];
             for (let [item, isSelected] of this.state.selectedItems) {
-                if (isSelected) selectedItems.push(item);
+                if (isSelected) selectedItems.push(JSON.parse(item));
             }
             return selectedItems;
         } else {
@@ -105,7 +105,7 @@ const listMixin = {
                 newSelectedItems.set(key, value);
             }
         }
-        newSelectedItems.set(data, isSelected);
+        newSelectedItems.set(JSON.stringify(data), isSelected);
 
         if (this.props.onSelection) {
             this.props.onSelection(data, isSelected);


### PR DESCRIPTION
## Selection List selection status

### Description

When the componenent receive a nes set of data. The `Map` of `selectedItems` do not behave as intended as it works on object instance for its key.


### Patch

We now use the `JSON.stringify` object as key in order to be sure to work on data.
> Fixes #820 
