### PR TITLE
[facet-box] Fix facet-box title default style

### DIFF
--- a/src/search/facet-box/style/facet-box.scss
+++ b/src/search/facet-box/style/facet-box.scss
@@ -37,7 +37,7 @@ $advanced-search-facet-box-width: 275px;
         cursor: pointer;
         position: relative;
         h2 {
-            font-size: 2em;
+            font-size: 34px;
             margin: 0;
             padding: 15px 0;
             border-bottom: 1px solid #e2e2e2;
@@ -48,7 +48,6 @@ $advanced-search-facet-box-width: 275px;
                 vertical-align: middle;
                 position: absolute;
                 right: 0;
-                top: 21px;
                 font-size: 30px;
             }
         }


### PR DESCRIPTION
Fix facet-box title default style

###  current rendering

![image](https://cloud.githubusercontent.com/assets/5349745/14487598/c23b1c12-0163-11e6-89db-f82b6a9450ef.png)

### rendu avec correction

![image](https://cloud.githubusercontent.com/assets/5349745/14487610/d1a30f16-0163-11e6-9f31-a86f99334caf.png)