### PR TITLE
Fix default empty translation

### DIFF
--- a/src/page/search/common/component/default-empty-component.js
+++ b/src/page/search/common/component/default-empty-component.js
@@ -1,19 +1,16 @@
 // Dependencies
-const React = require('react');
+import React, {Component} from 'react';
 import builder from 'focus-core/component/builder';
+import {translate} from 'focus-core/translation';
 
-// Mixins
-const i18nMixin = require('../../../../common/i18n/mixin');
-
-const DefaultEmpty = {
-    mixins: [i18nMixin],
+class DefaultEmpty extends Component {
     render() {
         return (
-                <div data-focus='empty-result'>
-                    {this.i18n('search.empty')}
-                </div>
-            );
+            <div data-focus='empty-result'>
+                {translate('search.empty')}
+            </div>
+        );
     }
-};
+}
 
-module.exports = builder(DefaultEmpty);
+module.exports = DefaultEmpty;

--- a/src/page/search/common/component/default-empty-component.js
+++ b/src/page/search/common/component/default-empty-component.js
@@ -3,14 +3,12 @@ import React, {Component} from 'react';
 import builder from 'focus-core/component/builder';
 import {translate} from 'focus-core/translation';
 
-class DefaultEmpty extends Component {
-    render() {
-        return (
-            <div data-focus='empty-result'>
-                {translate('search.empty')}
-            </div>
-        );
-    }
+function DefaultEmpty() {
+    return (
+        <div data-focus='empty-result'>
+            {translate('search.empty')}
+        </div>
+    );
 }
 
 module.exports = DefaultEmpty;

--- a/src/page/search/common/component/results.js
+++ b/src/page/search/common/component/results.js
@@ -15,7 +15,7 @@ const mapValues = require('lodash/object/mapValues');
 const omit = require('lodash/object/omit');
 
 // Components
-const DefaultEmpty = require('./default-empty-component').component;
+import DefaultEmpty from './default-empty-component';
 const ListSelection = require('../../../../list/selection').list.component;
 const GroupWrapper = require('./group-wrapper').component;
 


### PR DESCRIPTION
## [default-empty] Fix translation

### Description

[Description of the issue fixed or the new feature]
rewriting the component as a function and fixing the translation "search.empty" problem