### PR TITLE
[Search-Bar] Fix placeholder issue

### DIFF
--- a/src/behaviours/material/index.js
+++ b/src/behaviours/material/index.js
@@ -33,6 +33,13 @@ const Material = (ref, jsClass, watchedProp) => Component => class MaterialCompo
             Component.prototype.componentWillReceiveProps.call(this, nextProps);
         }
     }
+
+    componentWillUpdate() {
+        if(jsClass === 'MaterialTextfield') {
+            const refNode = ReactDOM.findDOMNode(this.refs[ref]);
+            refNode.MaterialTextfield.change(this.props.value)
+        }
+    }
 };
 
 Material.componentHandler = componentHandler;

--- a/src/behaviours/material/index.js
+++ b/src/behaviours/material/index.js
@@ -34,7 +34,7 @@ const Material = (ref, jsClass, watchedProp) => Component => class MaterialCompo
         }
     }
 
-    componentWillUpdate() {
+    componentDidUpdate() {
         if(jsClass === 'MaterialTextfield') {
             this.refs.inputText.MaterialTextfield.change(this.props.value);
         }

--- a/src/behaviours/material/index.js
+++ b/src/behaviours/material/index.js
@@ -37,7 +37,8 @@ const Material = (ref, jsClass, watchedProp) => Component => class MaterialCompo
     componentWillUpdate() {
         if(jsClass === 'MaterialTextfield') {
             const refNode = ReactDOM.findDOMNode(this.refs[ref]);
-            refNode.MaterialTextfield.change(this.props.value)
+            refNode.MaterialTextfield.change(this.props.value);
+            console.log(refNode);
         }
     }
 };

--- a/src/behaviours/material/index.js
+++ b/src/behaviours/material/index.js
@@ -36,9 +36,7 @@ const Material = (ref, jsClass, watchedProp) => Component => class MaterialCompo
 
     componentWillUpdate() {
         if(jsClass === 'MaterialTextfield') {
-            const refNode = ReactDOM.findDOMNode(this.refs[ref]);
-            refNode.MaterialTextfield.change(this.props.value);
-            console.log(refNode);
+            this.refs.inputText.MaterialTextfield.change(this.props.value);
         }
     }
 };

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -46,10 +46,6 @@ class InputText extends Component {
         return unformatter(domEl.value, MODE);
     };
 
-    // componentWillUpdate() {
-    //     this.refs.inputText.MaterialTextfield.change(this.props.value);
-    // }
-
     componentDidUpdate() {
         const {error} = this.props;
         if (!error) {

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -46,6 +46,10 @@ class InputText extends Component {
         return unformatter(domEl.value, MODE);
     };
 
+    // componentWillUpdate() {
+    //     this.refs.inputText.MaterialTextfield.change(this.props.value);
+    // }
+
     componentDidUpdate() {
         const {error} = this.props;
         if (!error) {

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -45,6 +45,11 @@ class InputText extends Component {
         const domEl = ReactDOM.findDOMNode(this.refs.htmlInput);
         return unformatter(domEl.value, MODE);
     };
+
+    componentDidUpdate() {
+        this.refs.inputText.MaterialTextfield.change(this.props.value);
+    }
+
     componentDidUpdate() {
         const {error} = this.props;
         if (!error) {

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -32,7 +32,7 @@ const defaultProps = {
 /**
  * Component standing for an HTML input.
  */
-@MDBehaviour('inputText')
+@MDBehaviour('inputText', 'MaterialTextfield')
 @ComponentBaseBehaviour
 class InputText extends Component {
 
@@ -45,10 +45,6 @@ class InputText extends Component {
         const domEl = ReactDOM.findDOMNode(this.refs.htmlInput);
         return unformatter(domEl.value, MODE);
     };
-
-    componentDidUpdate() {
-        this.refs.inputText.MaterialTextfield.change(this.props.value);
-    }
 
     componentDidUpdate() {
         const {error} = this.props;


### PR DESCRIPTION
## [Search-Bar] Fix placeholder issue

### Description

The placeholder stayed when the input value was already set and when the component was rendered.
![1193f8fc-115d-11e6-8a17-5b151da3f3c8](https://cloud.githubusercontent.com/assets/1215329/15190661/69c52fbe-17b1-11e6-81b8-f81aad357075.png)

### Patch

The placeholder was not updated. It's a material design lite input problem
We have to use the MaterialTextfield.change() function to update the component's placeholder correctly.

```
componentWillUpdate() { 
        this.refs.inputText.MaterialTextfield.change(this.props.value);
}
```

> Fixes #1137 