### PR TITLE
[Advanced Search] Fix when operation.style is undefined in lineOperationList

### DIFF
--- a/src/list/action-contextual/index.js
+++ b/src/list/action-contextual/index.js
@@ -72,7 +72,7 @@ const actionContextualMixin = {
                         iconLibrary={operation.iconLibrary}
                         key={key}
                         label={operation.label}
-                        shape={operation.style.shape || 'icon'}
+                        shape={operation.style && operation.style.shape || 'icon'}
                         style={operation.style || {}}
                         type='button'
                         {...this.props}


### PR DESCRIPTION
Advanced Search > config > lineOperationList
```javascript
           lineOperationList:
              [{
                priority: 1,
                icon: 'mail',
                style: {}, <= Not required after patch
                label: 'Contacter par e-mail',
                action: this.emailAction
              }
            ]
```
