### PR TITLE
[action-bar/advanced-search] Behaviour update

### DIFF
--- a/src/list/action-bar/index.js
+++ b/src/list/action-bar/index.js
@@ -164,7 +164,7 @@ const ActionBar = {
         return (
             <div className='mdl-grid' data-focus='list-action-bar'>
                 <div className='mdl-cell' data-focus='global-list-content'>
-                    {this._getSelectionObject()}
+                    {this.props.isSelection && this._getSelectionObject()}
                     {this._getOrderObject()}
                     {this._getGroupObject()}
                 </div>


### PR DESCRIPTION
## [action-bar/advanced-search] : Behaviour update

### Description


### Patch
> Fixes #1131 

There, i hide the checkbox when it's not need, when the isSelection is set to false
This is interesting, for example, an order button as in the issue. But if you don't have anything, you'll have this : 

![empty](https://cloud.githubusercontent.com/assets/1215329/15389937/8a7cf328-1db9-11e6-8d9a-db914cadbe13.png)

So we gotta think about the logic. What do we want to display when there is no other button in the action bar