### PR TITLE
upgrade mdl version to 1.1.3 & release beta version of focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "exports-loader": "^0.6.2",
         "extract-text-webpack-plugin": "^0.8.2",
         "file-loader": "^0.8.4",
-        "focus-core": "0.14.0-beta0",
+        "focus-core": "0.16.0-beta0",
         "in-publish": "^2.0.0",
         "jquery": "^2.1.4",
         "jsdom": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "focus-components",
-    "version": "0.15.5-beta1",
+    "version": "0.16.0-beta0",
     "description": "Focus component repository.",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,134 +1,134 @@
 {
-  "name": "focus-components",
-  "version": "0.15.5-beta1",
-  "description": "Focus component repository.",
-  "main": "index.js",
-  "scripts": {
-    "babelify": "better-npm-run babelify",
-    "bundle": "better-npm-run bundle",
-    "copy-sass": "better-npm-run copy-sass",
-    "build": "node scripts/mdl-variables-copy.js && better-npm-run babelify && better-npm-run copy-sass && better-npm-run bundle",
-    "test": "better-npm-run test",
-    "test:watch": "better-npm-run test-watch",
-    "postinstall": "node scripts/mdl-variables-copy.js",
-    "profile": "better-npm-run profile",
-    "fix-lint": "eslint --fix src/** || exit 0"
-  },
-  "betterScripts": {
-    "babelify": {
-      "env": {
-        "BABEL_ENV": "production"
-      },
-      "command": "node scripts/babelify.js"
+    "name": "focus-components",
+    "version": "0.15.5-beta1",
+    "description": "Focus component repository.",
+    "main": "index.js",
+    "scripts": {
+        "babelify": "better-npm-run babelify",
+        "bundle": "better-npm-run bundle",
+        "copy-sass": "better-npm-run copy-sass",
+        "build": "node scripts/mdl-variables-copy.js && better-npm-run babelify && better-npm-run copy-sass && better-npm-run bundle",
+        "test": "better-npm-run test",
+        "test:watch": "better-npm-run test-watch",
+        "postinstall": "node scripts/mdl-variables-copy.js",
+        "profile": "better-npm-run profile",
+        "fix-lint": "eslint --fix src/** || exit 0"
     },
-    "copy-sass": {
-      "command": "cd src && find . -name *.scss | xargs tar cvf - | tar xfp - -C ../"
+    "betterScripts": {
+        "babelify": {
+            "env": {
+                "BABEL_ENV": "production"
+            },
+            "command": "node scripts/babelify.js"
+        },
+        "copy-sass": {
+            "command": "cd src && find . -name *.scss | xargs tar cvf - | tar xfp - -C ../"
+        },
+        "bundle": {
+            "command": "webpack --progress",
+            "env": {
+                "DEV": false,
+                "NODE_ENV": "production",
+                "LIBRARY_NAME": "FocusComponents",
+                "MINIMIFY": false,
+                "PACKAGE_JSON_PATH": "../",
+                "BABEL_ENV": "production"
+            }
+        },
+        "profile": {
+            "command": "webpack --progress --json --profile > profile.json",
+            "env": {
+                "DEV": false,
+                "NODE_ENV": "production",
+                "LIBRARY_NAME": "FocusComponents",
+                "MINIMIFY": false,
+                "PACKAGE_JSON_PATH": "../"
+            }
+        },
+        "test": {
+            "command": "mocha src/**/__tests__/**/*.js",
+            "env": {
+                "BABEL_ENV": "production"
+            }
+        },
+        "test-watch": {
+            "command": "mocha src/**/__tests__/**/*.js -w",
+            "env": {
+                "BABEL_ENV": "production"
+            }
+        }
     },
-    "bundle": {
-      "command": "webpack --progress",
-      "env": {
-        "DEV": false,
-        "NODE_ENV": "production",
-        "LIBRARY_NAME": "FocusComponents",
-        "MINIMIFY": false,
-        "PACKAGE_JSON_PATH": "../",
-        "BABEL_ENV": "production"
-      }
+    "babel": {
+        "presets": [
+            "focus"
+        ]
     },
-    "profile": {
-      "command": "webpack --progress --json --profile > profile.json",
-      "env": {
-        "DEV": false,
-        "NODE_ENV": "production",
-        "LIBRARY_NAME": "FocusComponents",
-        "MINIMIFY": false,
-        "PACKAGE_JSON_PATH": "../"
-      }
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/KleeGroup/focus-components.git"
     },
-    "test": {
-      "command": "mocha src/**/__tests__/**/*.js",
-      "env": {
-        "BABEL_ENV": "production"
-      }
+    "keywords": [
+        "react",
+        "focus"
+    ],
+    "author": "Focus Team <focus@kleegroup.com>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/KleeGroup/focus-components/issues"
     },
-    "test-watch": {
-      "command": "mocha src/**/__tests__/**/*.js -w",
-      "env": {
-        "BABEL_ENV": "production"
-      }
+    "homepage": "https://github.com/KleeGroup/focus-components",
+    "dependencies": {
+        "daterangepicker": "0.0.3",
+        "immutable": "^3.7.4",
+        "lodash": "^3.10.1",
+        "material-design-lite": "1.1.3",
+        "object-assign": "^2.0.0",
+        "react-addons-css-transition-group": "^0.14.7",
+        "react-date-picker": "^3.1.6",
+        "react-tap-event-plugin": "^0.2.1",
+        "uuid": "^2.0.1"
+    },
+    "devDependencies": {
+        "autoprefixer-loader": "^3.2.0",
+        "babel": "^6.3.26",
+        "babel-cli": "^6.4.0",
+        "babel-core": "^6.4.0",
+        "babel-eslint": "4.1.3",
+        "babel-loader": "^6.2.1",
+        "babel-preset-focus": "^0.5.2",
+        "babel-runtime": "^6.3.19",
+        "better-npm-run": "0.0.5",
+        "chai": "^3.2.0",
+        "chai-subset": "^1.0.1",
+        "css-loader": "^0.19.0",
+        "eslint": "^2.3.0",
+        "eslint-config-focus": "0.3.0",
+        "eslint-plugin-filenames": "0.1.1",
+        "eslint-plugin-react": "3.5.0",
+        "exports-loader": "^0.6.2",
+        "extract-text-webpack-plugin": "^0.8.2",
+        "file-loader": "^0.8.4",
+        "focus-core": "0.14.0-beta0",
+        "in-publish": "^2.0.0",
+        "jquery": "^2.1.4",
+        "jsdom": "^6.4.0",
+        "json-loader": "^0.5.3",
+        "mocha": "^2.2.5",
+        "moment": "^2.10.6",
+        "node-sass": "^3.3.3",
+        "numeral": "^1.5.3",
+        "react": "^0.14.7",
+        "react-addons-test-utils": "^0.14.7",
+        "react-dom": "^0.14.7",
+        "react-hot-loader": "^1.3.0",
+        "sass-loader": "^2.0.1",
+        "sinon": "^1.16.1",
+        "sinon-chai": "^2.8.0",
+        "source-map-loader": "^0.1.5",
+        "style-loader": "^0.12.4",
+        "url-loader": "^0.5.6",
+        "webpack": "^1.12.14",
+        "webpack-dev-server": "^1.14.1",
+        "webpack-focus": "^0.11.4"
     }
-  },
-  "babel": {
-    "presets": [
-      "focus"
-    ]
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/KleeGroup/focus-components.git"
-  },
-  "keywords": [
-    "react",
-    "focus"
-  ],
-  "author": "Focus Team <focus@kleegroup.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/KleeGroup/focus-components/issues"
-  },
-  "homepage": "https://github.com/KleeGroup/focus-components",
-  "dependencies": {
-    "daterangepicker": "0.0.3",
-    "immutable": "^3.7.4",
-    "lodash": "^3.10.1",
-    "material-design-lite": "1.1.2",
-    "object-assign": "^2.0.0",
-    "react-addons-css-transition-group": "^0.14.7",
-    "react-date-picker": "^3.1.6",
-    "react-tap-event-plugin": "^0.2.1",
-    "uuid": "^2.0.1"
-  },
-  "devDependencies": {
-    "autoprefixer-loader": "^3.2.0",
-    "babel": "^6.3.26",
-    "babel-cli": "^6.4.0",
-    "babel-core": "^6.4.0",
-    "babel-eslint": "4.1.3",
-    "babel-loader": "^6.2.1",
-    "babel-preset-focus": "^0.5.2",
-    "babel-runtime": "^6.3.19",
-    "better-npm-run": "0.0.5",
-    "chai": "^3.2.0",
-    "chai-subset": "^1.0.1",
-    "css-loader": "^0.19.0",
-    "eslint": "^2.3.0",
-    "eslint-config-focus": "0.3.0",
-    "eslint-plugin-filenames": "0.1.1",
-    "eslint-plugin-react": "3.5.0",
-    "exports-loader": "^0.6.2",
-    "extract-text-webpack-plugin": "^0.8.2",
-    "file-loader": "^0.8.4",
-    "focus-core": "0.14.0-beta0",
-    "in-publish": "^2.0.0",
-    "jquery": "^2.1.4",
-    "jsdom": "^6.4.0",
-    "json-loader": "^0.5.3",
-    "mocha": "^2.2.5",
-    "moment": "^2.10.6",
-    "node-sass": "^3.3.3",
-    "numeral": "^1.5.3",
-    "react": "^0.14.7",
-    "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^0.14.7",
-    "react-hot-loader": "^1.3.0",
-    "sass-loader": "^2.0.1",
-    "sinon": "^1.16.1",
-    "sinon-chai": "^2.8.0",
-    "source-map-loader": "^0.1.5",
-    "style-loader": "^0.12.4",
-    "url-loader": "^0.5.6",
-    "webpack": "^1.12.14",
-    "webpack-dev-server": "^1.14.1",
-    "webpack-focus": "^0.11.4"
-  }
 }


### PR DESCRIPTION
# Current behaviour

Update Material Design Lite version to 1.1.3, which is available and fix some issue about snackbar display.

Further information about this release here : https://github.com/google/material-design-lite/releases/tag/v1.1.3
