### PR TITLE
[Autocomplete-select] Import React is missing

### DIFF
--- a/src/components/input/autocomplete-select/consult.js
+++ b/src/components/input/autocomplete-select/consult.js
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import React, {Component} from 'react';
 import ComponentBaseBehaviour from '../../../behaviours/component-base';
 
 @ComponentBaseBehaviour


### PR DESCRIPTION
## [Autocomplete-select] fix import React missing

### Description

The import was missing and composant couldn't be render 

