### PR TITLE
Add error when it is used in fieldFor

### DIFF
--- a/src/common/select/radio/index.js
+++ b/src/common/select/radio/index.js
@@ -101,9 +101,11 @@ const selectRadioMixin = {
     },
     /** @inheritdoc */
     render() {
+        const {error} = this.props;
         return (
-            <div data-focus='select-radio'>
+            <div data-focus='select-radio' data-valid={!error}>
                 {this.renderSelectRadios()}
+                {error && <div className='label-error' ref='error'>{error}</div>}
             </div>
         );
     }

--- a/src/common/select/radio/style/select-radio.scss
+++ b/src/common/select/radio/style/select-radio.scss
@@ -1,4 +1,10 @@
 
 [data-focus="select-radio"] {
-    
+    &[data-valid='false'] {
+        .label-error {
+            color: $select-error-color;
+            position: absolute;
+            font-size: 12px;
+        }
+    }
 }


### PR DESCRIPTION
## [Select-radio] Add error to the component

### Description

The component doesn't show validation error. Now, it does (I think)

