### PR TITLE
Fix facet sorting

### DIFF
--- a/src/search/facet-box/facet.js
+++ b/src/search/facet-box/facet.js
@@ -34,7 +34,7 @@ const Facet = {
         facet: PropTypes.array,
         isShowAll: PropTypes.bool,
         nbDefaultDataList: PropTypes.number
-    }
+    },
     /**
      * Render the component.
      * @returns {XML} Html component code.

--- a/src/search/facet-box/facet.js
+++ b/src/search/facet-box/facet.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 import builder from 'focus-core/component/builder';
 import {keys} from 'lodash/object';
 import {isObject} from 'lodash/lang';
@@ -30,6 +30,11 @@ const Facet = {
             nbDefaultDataList: 6
         };
     },
+    propTypes: {
+        facet: PropTypes.array,
+        isShowAll: PropTypes.bool,
+        nbDefaultDataList: PropTypes.number
+    }
     /**
      * Render the component.
      * @returns {XML} Html component code.
@@ -86,15 +91,20 @@ const Facet = {
         if (!this.props.isExpanded || this.props.selectedDataKey) {
             return '';
         }
-        let keysList = this.state.isShowAll ? keys(this.props.facet) : keys(this.props.facet).slice(0, this.props.nbDefaultDataList);
+        // The parsed facets are now an array
+        const facetValues = this.state.isShowAll ? this.props.facet : this.props.facet.slice(0, this.props.nbDefaultDataList);
         return (
             <div className='' data-focus='facet-data-list'>
                 <ul>
-                    {keysList.map((key) => {
+                    {facetValues.map( facetValue => {
                         return (
-                            <li key={key}>
-                                <FacetData dataKey={key} data={this.props.facet[key]} selectHandler={this._facetDataSelectionHandler}
-                                    type={this.props.type}/>
+                            <li key={facetValue.label}>
+                                <FacetData
+                                    dataKey={facetValue.label}
+                                    data={facetValue}
+                                    selectHandler={this._facetDataSelectionHandler}
+                                    type={this.props.type}
+                                />
                             </li>
                         );
                     })}


### PR DESCRIPTION
## Facet values sort parsing

### Description

The search parsing was incorrect, it didn't preserve the sort from the server as the facet content was an object instead of an array.

### Fix

- [x] Now the parsing result returns an array for the facet content and the component uses this new contract.
- [x] Add `PropTypes`

It partially fixes https://github.com/KleeGroup/focus-components/issues/1207
it is also correlated to https://github.com/KleeGroup/focus-core/pull/368