### PR TITLE
[Input date] add otherProps into date components

### DIFF
--- a/src/components/input/date/__tests__/index.js
+++ b/src/components/input/date/__tests__/index.js
@@ -10,18 +10,38 @@ global.componentHandler = {
 describe('The input date', () => {
     describe('when mounted with a valid value', () => {
         const now = new Date().toISOString();
-        let renderedTest;
+        let reactComponent, domNode, inputNode;
         const onChangeSpy = sinon.spy();
         before(() => {
-            renderedTest = TestUtils.renderIntoDocument(<InputDate onChange={onChangeSpy} value={now} />);
+            reactComponent = TestUtils.renderIntoDocument(<InputDate onChange={onChangeSpy} value={now} />);
+            domNode = ReactDOM.findDOMNode(reactComponent);
         });
-
+        it('should render a node with data-focus attribute', () => {
+            expect(reactComponent).to.exist;
+            expect(reactComponent).to.be.an('object');
+            expect(domNode.tagName).to.equal('DIV');
+            expect(domNode.getAttribute('data-focus')).to.equal('input-date');
+        });
         it('should hold the provided initial value', () => {
-            expect(moment(renderedTest.getValue()).isSame(now, 'day')).to.be.true;
+            expect(moment(reactComponent.getValue()).isSame(now, 'day')).to.be.true;
         });
 
         it('should display the provided date in the dropdown', () => {
-            expect(moment(renderedTest.state.dropDownDate.toISOString()).isSame(now, 'day')).to.be.true;
+            expect(moment(reactComponent.state.dropDownDate.toISOString()).isSame(now, 'day')).to.be.true;
+        });
+    });
+
+
+    describe('when mounted with a disabled props', () => {
+        const now = new Date().toISOString();
+        let reactComponent, inputNode;
+        const onChangeSpy = sinon.spy();
+        before(() => {
+            reactComponent = TestUtils.renderIntoDocument(<InputDate onChange={onChangeSpy} value={now} disabled={true} />);
+            inputNode = ReactDOM.findDOMNode(reactComponent.refs.input.refs.htmlInput);
+        });
+        it('should render a node with disabled attribute', () => {
+            expect(inputNode.hasAttribute('disabled')).to.be.true;
         });
     });
 

--- a/src/components/input/date/index.js
+++ b/src/components/input/date/index.js
@@ -169,10 +169,10 @@ class InputDate extends Component {
     };
 
     render() {
-        const {error, locale, name, placeholder, ...otherProps} = this.props;
+        const {error, locale, name, placeholder, disabled} = this.props;
         const {dropDownDate, inputDate, displayPicker} = this.state;
         const {_onInputBlur, _onInputChange, _onInputFocus, _onDropDownChange, _onPickerCloserClick, _handleKeyDown} = this;
-        const inputProps = { disabled: otherProps.disabled };
+        const inputProps = { disabled };
         return (
             <div data-focus='input-date'>
                 <InputText error={error} name={name} onChange={_onInputChange} onKeyDown={_handleKeyDown} onFocus={_onInputFocus} placeholder={placeholder} ref='input' value={inputDate} {...inputProps} />

--- a/src/components/input/date/index.js
+++ b/src/components/input/date/index.js
@@ -172,9 +172,10 @@ class InputDate extends Component {
         const {error, locale, name, placeholder, ...otherProps} = this.props;
         const {dropDownDate, inputDate, displayPicker} = this.state;
         const {_onInputBlur, _onInputChange, _onInputFocus, _onDropDownChange, _onPickerCloserClick, _handleKeyDown} = this;
+        const inputProps = { disabled: otherProps.disabled };
         return (
             <div data-focus='input-date'>
-                <InputText error={error} name={name} onChange={_onInputChange} onKeyDown={_handleKeyDown} onFocus={_onInputFocus} placeholder={placeholder} ref='input' value={inputDate} {...otherProps} />
+                <InputText error={error} name={name} onChange={_onInputChange} onKeyDown={_handleKeyDown} onFocus={_onInputFocus} placeholder={placeholder} ref='input' value={inputDate} {...inputProps} />
                 {displayPicker &&
                     <div data-focus='picker-zone'>
                         <DatePicker

--- a/src/components/input/date/index.js
+++ b/src/components/input/date/index.js
@@ -169,12 +169,12 @@ class InputDate extends Component {
     };
 
     render() {
-        const {error, locale, name, placeholder} = this.props;
+        const {error, locale, name, placeholder, ...otherProps} = this.props;
         const {dropDownDate, inputDate, displayPicker} = this.state;
         const {_onInputBlur, _onInputChange, _onInputFocus, _onDropDownChange, _onPickerCloserClick, _handleKeyDown} = this;
         return (
             <div data-focus='input-date'>
-                <InputText error={error} name={name} onChange={_onInputChange} onKeyDown={_handleKeyDown} onFocus={_onInputFocus} placeholder={placeholder} ref='input' value={inputDate} />
+                <InputText error={error} name={name} onChange={_onInputChange} onKeyDown={_handleKeyDown} onFocus={_onInputFocus} placeholder={placeholder} ref='input' value={inputDate} {...otherProps} />
                 {displayPicker &&
                     <div data-focus='picker-zone'>
                         <DatePicker


### PR DESCRIPTION
## [Input date] add otherProps into date components

### Description

Previously, it was not possible to disable input date component because otherProps were not passed to InputComponents.

### Patch

Other props declared into the input date are now passed to his sub-component InputText.

### How to use it ?

```javascript
{this.fieldFor('birthDate', {options:{disabled: true}})}
```

Fixes #1212