### PR TITLE
Correction for the sentence when the querry is empty

### DIFF
--- a/src/list/summary/index.js
+++ b/src/list/summary/index.js
@@ -39,7 +39,7 @@ const listSummaryMixin = {
     _getResultSentence() {
         const {nb, queryText} = this.props;
         const hasText = queryText && queryText.trim().length > 0;
-        const sentence = nb > 1 ? 'results.for' : 'result.for';
+        const sentence = nb > 1 ? hasText ? 'results.for' : 'results' : hasText ? 'result.for' : 'result';
         return (
             <span>
                 <strong>{numberFormatter.format(nb)}&nbsp;</strong>


### PR DESCRIPTION
## [Advanced Search] Correction for the sentence when the querry is empty

### Description

Currently, when the querry is empty the sentence writes 'results for' but the flollowing is empty. So the sentence must write only 'results'

