### PR TITLE
Add ButtonHelp and add toggle logic to DraggableIframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "focus-components",
-    "version": "0.17.0-beta2",
+    "version": "0.17.0-beta3",
     "description": "Focus component repository.",
     "main": "index.js",
     "scripts": {

--- a/src/components/button-help/index.js
+++ b/src/components/button-help/index.js
@@ -23,7 +23,7 @@ function ButtonHelp({blockName}) {
     );
 }
 
-HelpButton.propTypes = {
+ButtonHelp.propTypes = {
     blockName: PropTypes.string
 };
 

--- a/src/components/button-help/index.js
+++ b/src/components/button-help/index.js
@@ -1,0 +1,29 @@
+import React, {PropTypes} from 'react';
+import Button from '../button';
+import {translate} from 'focus-core/translation';
+
+function ButtonHelp({blockName}) {
+    const {hash, pathname} = window.location;
+    const url = hash && hash.replace('#', '') || pathname;
+    const {openHelpCenter} = window;
+
+    if (typeof openHelpCenter !== 'function') {
+        console.warn('You forgot to set the function "window.openHelpCenter". Please mount somewhere in your application a "DraggableIframe" with "openHelpCenter" as the "toggleFunctionName" prop');
+    }
+
+    return (
+        <Button
+            className='help-button'         
+            handleOnClick={() => openHelpCenter(url, blockName)}
+            icon='help_outline'
+            label={`${translate('help.alt')} : ${blockName}`}
+            shape='icon'
+        />
+    );
+}
+
+HelpButton.propTypes = {
+    blockName: PropTypes.string
+};
+
+export default ButtonHelp;

--- a/src/components/button-help/index.js
+++ b/src/components/button-help/index.js
@@ -18,6 +18,7 @@ function ButtonHelp({blockName}) {
             icon='help_outline'
             label={`${translate('help.alt')} : ${blockName}`}
             shape='icon'
+            type='button'
         />
     );
 }

--- a/src/components/draggable-iframe/index.js
+++ b/src/components/draggable-iframe/index.js
@@ -14,7 +14,9 @@ export default class DraggableIframe extends React.Component {
     
     constructor(props) {
         super(props);
-        window[props.toggleFunctionName] = this.toggle;
+        if (props.toggleFunctionName) {
+            window[props.toggleFunctionName] = this.toggle;
+        }
     }
 
     state = {

--- a/src/components/draggable-iframe/index.js
+++ b/src/components/draggable-iframe/index.js
@@ -69,8 +69,8 @@ export default class DraggableIframe extends React.Component {
         const {title, iframeUrl, width, height, queryUrl} = this.props;
         const {selected, isShown, params} = this.state;
         const url = iframeUrl + params.map((param, i) => typeof queryUrl[i] === 'string' ? queryUrl[i] + param : '').join('');
-        return isShown ? (
-            <div className={`help-frame ${selected ? 'is-dragging' : ''}`} onMouseDown={this.dragInit} ref='helpFrame' style={{width}}>
+        return (
+            <div className={`help-frame ${selected ? 'is-dragging' : ''}`} onMouseDown={this.dragInit} ref='helpFrame' style={{width, display: isShown ? 'block' : 'none'}}>
                 <span className='help-center-title'>{translate(title)}</span>
                 <div className='mdl-button mdl-js-button mdl-button--icon mdl-js-ripple-effect close-icon' onClick={this.toggle}>
                     <i className='material-icons'>close</i>
@@ -78,7 +78,7 @@ export default class DraggableIframe extends React.Component {
                 <br />
                 <IFrame height={height} src={url} width={width} />
             </div>
-        ) : null;
+        );
     }
 }
 

--- a/src/components/draggable-iframe/index.js
+++ b/src/components/draggable-iframe/index.js
@@ -8,10 +8,18 @@ export default class DraggableIframe extends React.Component {
         width: PropTypes.number.isRequired,
         height: PropTypes.number.isRequired,
         title: PropTypes.string.isRequired,
-        requestClose: PropTypes.func.isRequired
+        toggleFunctionName: PropTypes.string,
+        queryUrl: PropTypes.array
     };
+    
+    constructor(props) {
+        super(props);
+        window[props.toggleFunctionName] = this.toggle;
+    }
 
     state = {
+        isShown: false,
+        params: [],
         xPos: 0,
         yPos: 0,
         xElem: 0,
@@ -50,18 +58,35 @@ export default class DraggableIframe extends React.Component {
         document.onmouseup = null;
         this.setState({selected: null});
     };
+
+    toggle = (...params) => {
+        this.setState({isShown: !this.state.isShown, params});
+    }
     
     render() {
-        const {requestClose, title, iframeUrl, width, height} = this.props;
-        return (
-            <div className={`help-frame ${this.state.selected ? 'is-dragging' : ''}`} onMouseDown={this.dragInit} ref='helpFrame' style={{width}}>
+        const {title, iframeUrl, width, height, queryUrl} = this.props;
+        const {selected, isShown, params} = this.state;
+        const url = iframeUrl + params.map((param, i) => typeof queryUrl[i] === 'string' ? queryUrl[i] + param : '').join('');
+        return isShown ? (
+            <div className={`help-frame ${selected ? 'is-dragging' : ''}`} onMouseDown={this.dragInit} ref='helpFrame' style={{width}}>
                 <span className='help-center-title'>{translate(title)}</span>
-                <div className='mdl-button mdl-js-button mdl-button--icon mdl-js-ripple-effect close-icon' onClick={requestClose}>
+                <div className='mdl-button mdl-js-button mdl-button--icon mdl-js-ripple-effect close-icon' onClick={this.toggle}>
                     <i className='material-icons'>close</i>
                 </div>
                 <br />
-                <iframe frameBorder={0} height={height} src={iframeUrl} width={width} />
+                <IFrame height={height} src={url} width={width} />
             </div>
-        );
+        ) : null;
+    }
+}
+
+class IFrame extends React.Component {
+    shouldComponentUpdate({src}) {
+        return src !== this.props.src;
+    }
+
+    render() {
+        const {height, src, width} = this.props;
+        return <iframe frameBorder={0} height={height} src={src} width={width} />;
     }
 }

--- a/src/components/draggable-iframe/index.js
+++ b/src/components/draggable-iframe/index.js
@@ -62,7 +62,11 @@ export default class DraggableIframe extends React.Component {
     };
 
     toggle = (...params) => {
-        this.setState({isShown: !this.state.isShown, params});
+        const {yPos: oldPos, isShown, yElem} = this.state;
+        const {pageYOffset, outerHeight} = window;
+        const yPos = isShown ? oldPos : pageYOffset > oldPos ? pageYOffset + 50 : pageYOffset + outerHeight < oldPos ? pageYOffset + outerHeight - this.props.height - 100 : oldPos;
+        this.setState({isShown: !this.state.isShown, params, yPos});
+        this.refs.helpFrame.style.top = (yPos - yElem) + 'px';
     }
     
     render() {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,6 +16,7 @@ import ScrollspyContainer from './scrollspy-container';
 import Button from './button';
 import ButtonBackToTop from './button-back-to-top';
 import ButtonBack from './button-back';
+import ButtonHelp from './button-help';
 import Grid from './grid';
 import Column from './column';
 import Icon from './icon';
@@ -46,6 +47,7 @@ export default {
     Button,
     ButtonBackToTop,
     ButtonBack,
+    ButtonHelp,
     Grid,
     Column,
     Icon,

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react';
+import {findDOMNode} from 'react-dom';
 import Translation from '../../behaviours/translation';
 import {includes} from 'lodash/collection';
 import {uniqueId} from 'lodash/utility';

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -4,6 +4,7 @@ import {includes} from 'lodash/collection';
 import {uniqueId} from 'lodash/utility';
 import {snakeCase} from 'lodash/string';
 import ButtonHelp from '../button-help';
+import xor from 'lodash/array/xor';
 
 const defaultProps = {
     actionsPosition: 'top'
@@ -27,6 +28,33 @@ class Panel extends Component {
             spyId: uniqueId('panel_')
         };
         this.state = state;
+    }
+
+    /**
+     * Recalculate the spyId to match the true order in the eventual ScrollspyContainer.
+     */
+    componentDidMount() {
+        const node = findDOMNode(this);
+        let scrollspy = node;
+        while (scrollspy && scrollspy.getAttribute('data-focus') !== 'scrollspy-container') {
+            scrollspy = scrollspy.parentElement;
+        }
+        if (scrollspy) {
+            const panels = scrollspy.querySelectorAll(`[data-focus='panel']`);
+            const popinPanels = scrollspy.querySelectorAll(`[data-focus='popin-window'] [data-spy]`);
+            const panelsInScrollspy = xor(panels, popinPanels);
+            if (panelsInScrollspy.length) {
+                panelsInScrollspy.forEach((child, idx) => {
+                    if (child.getAttribute('data-spy') === this.state.spyId) {
+                        this.setState({spyId: `panel_${idx + 1}`})
+                    }
+                });
+            } else {
+                this.setState({spyId: 'panel_0'});
+            }
+        } else {
+            this.setState({spyId: 'panel_0'});
+        }
     }
 
     /**

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react';
 import Translation from '../../behaviours/translation';
 import {includes} from 'lodash/collection';
 import {uniqueId} from 'lodash/utility';
+import {snakeCase} from 'lodash/string';
+import ButtonHelp from '../button-help';
 
 const defaultProps = {
     actionsPosition: 'top'
@@ -10,7 +12,8 @@ const defaultProps = {
 const propTypes = {
     actions: PropTypes.func,
     actionsPosition: PropTypes.oneOf(['both', 'bottom', 'top']).isRequired,
-    title: PropTypes.string
+    title: PropTypes.string,
+    showHelp: PropTypes.boolean
 };
 
 /**
@@ -31,7 +34,7 @@ class Panel extends Component {
     * @return {DOM} React DOM element
     */
     render() {
-        const {actions, actionsPosition, children, title, ...otherProps} = this.props;
+        const {actions, actionsPosition, children, title, showHelp, ...otherProps} = this.props;
         const {spyId} = this.state;
         const shouldDisplayActionsTop = actions && includes(['both', 'top'], actionsPosition);
         const shouldDisplayActionsBottom = actions && includes(['both', 'bottom'], actionsPosition);
@@ -44,6 +47,7 @@ class Panel extends Component {
                     {shouldDisplayActionsTop &&
                         <div className='actions'>{actions()}</div>
                     }
+                    {showHelp && <ButtonHelp blockName={`${snakeCase(this.i18n(title))}-${spyId && spyId.replace('panel_', '') || 0}`} />}
                 </div>
                 <div className='mdl-card__supporting-text' data-focus='panel-content'>
                     {children}

--- a/src/components/panel/style/panel.scss
+++ b/src/components/panel/style/panel.scss
@@ -21,6 +21,10 @@ $panel-border-size:3px;
             color:$panel-title-color;
             display: inline-block;
         }
+        .help-button {
+            position: absolute;
+            right: 20px;
+        }
     }
     .actions {
         display: none;


### PR DESCRIPTION
## ButtonHelp and integration in Panel

### Description

#### New component: `ButtonHelp`.
It is an icon button that opens the help center with the current URL and the block given as prop. It is integrated into the `Panel` component through a new `showHelp` prop that generates the blockName from the `title` and the `spyId`.

#### Panel spyId
Currently, the spyId on each Panel is given by the `uniqueId` method from lodash, which gives a new number for each new Panel that is instantiated in the app. So that means that the spyIds aren't constant, so they can't be used as an id for identifying a block. To remedy this, I redefine the spyId for each Panel on its `componentDidMount()`event so that it matches its position in the Scrollspy if it is indeed in one. Otherwise, it's set to 0. I'm pretty sure it won't break anything since those spyIds weren't reliable. 

#### DraggableIframe
The component now handles its own displayed or not state and publishes a method on the `window` object to toggle it. The name of that method is specified with the `toggleFunctionName' prop and should be 'openHelpCenter` for `ButtonHelp`.

It also takes a new `queryUrl` prop which is an array of string containing the different parts of the eventual query url that will be completed with the toggle function arguments.
Exemple: `['query?url=', '&block=']` will be used to complete the iframe url like this `query?url={args[0]}&block={args[1]}`.
(that might not be the most elegent way but it is by far the simplest one).

### Example
![capture](https://cloud.githubusercontent.com/assets/3266897/17899218/d3f86bc6-695a-11e6-9cce-b3946eed42b9.PNG)
