### PR TITLE
Panel fixes for help center

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "focus-components",
-    "version": "0.17.0-beta4",
+    "version": "0.17.0-beta5",
     "description": "Focus component repository.",
     "main": "index.js",
     "scripts": {

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -15,7 +15,7 @@ const propTypes = {
     actions: PropTypes.func,
     actionsPosition: PropTypes.oneOf(['both', 'bottom', 'top']).isRequired,
     title: PropTypes.string,
-    showHelp: PropTypes.boolean
+    showHelp: PropTypes.bool
 };
 
 /**

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -32,7 +32,7 @@ class Panel extends Component {
     }
 
     /**
-     * Recalculate the spyId to match the true order in the eventual ScrollspyContainer.
+     * Calculates the helpId to match the true order in an eventual ScrollspyContainer.
      */
     componentDidMount() {
         const node = findDOMNode(this);
@@ -47,14 +47,14 @@ class Panel extends Component {
             if (panelsInScrollspy.length) {
                 panelsInScrollspy.forEach((child, idx) => {
                     if (child.getAttribute('data-spy') === this.state.spyId) {
-                        this.setState({spyId: `panel_${idx + 1}`})
+                        this.setState({helpId: idx + 1})
                     }
                 });
             } else {
-                this.setState({spyId: 'panel_0'});
+                this.setState({helpId: 0});
             }
         } else {
-            this.setState({spyId: 'panel_0'});
+            this.setState({helpId: 0});
         }
     }
 

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -76,7 +76,7 @@ class Panel extends Component {
                     {shouldDisplayActionsTop &&
                         <div className='actions'>{actions()}</div>
                     }
-                    {showHelp && <ButtonHelp blockName={`${snakeCase(this.i18n(title))}-${spyId && spyId.replace('panel_', '') || 0}`} />}
+                    {showHelp && <ButtonHelp blockName={`${snakeCase(this.i18n(title)).split('_')[0]}-${spyId && spyId.replace('panel_', '') || 0}`} />}
                 </div>
                 <div className='mdl-card__supporting-text' data-focus='panel-content'>
                     {children}

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -15,7 +15,8 @@ const propTypes = {
     actions: PropTypes.func,
     actionsPosition: PropTypes.oneOf(['both', 'bottom', 'top']).isRequired,
     title: PropTypes.string,
-    showHelp: PropTypes.bool
+    showHelp: PropTypes.bool,
+    blockName: PropTypes.string
 };
 
 /**
@@ -32,38 +33,11 @@ class Panel extends Component {
     }
 
     /**
-     * Calculates the helpId to match the true order in an eventual ScrollspyContainer.
-     */
-    componentDidMount() {
-        const node = findDOMNode(this);
-        let scrollspy = node;
-        while (scrollspy && scrollspy.getAttribute('data-focus') !== 'scrollspy-container') {
-            scrollspy = scrollspy.parentElement;
-        }
-        if (scrollspy) {
-            const panels = scrollspy.querySelectorAll(`[data-focus='panel']`);
-            const popinPanels = scrollspy.querySelectorAll(`[data-focus='popin-window'] [data-spy]`);
-            const panelsInScrollspy = xor(panels, popinPanels);
-            if (panelsInScrollspy.length) {
-                panelsInScrollspy.forEach((child, idx) => {
-                    if (child.getAttribute('data-spy') === this.state.spyId) {
-                        this.setState({helpId: idx + 1})
-                    }
-                });
-            } else {
-                this.setState({helpId: 0});
-            }
-        } else {
-            this.setState({helpId: 0});
-        }
-    }
-
-    /**
     * Render the a block container and the cild content of the block.
     * @return {DOM} React DOM element
     */
     render() {
-        const {actions, actionsPosition, children, title, showHelp, ...otherProps} = this.props;
+        const {actions, actionsPosition, children, title, showHelp, blockName, ...otherProps} = this.props;
         const {spyId} = this.state;
         const shouldDisplayActionsTop = actions && includes(['both', 'top'], actionsPosition);
         const shouldDisplayActionsBottom = actions && includes(['both', 'bottom'], actionsPosition);
@@ -76,7 +50,7 @@ class Panel extends Component {
                     {shouldDisplayActionsTop &&
                         <div className='actions'>{actions()}</div>
                     }
-                    {showHelp && <ButtonHelp blockName={`${snakeCase(this.i18n(title)).split('_')[0]}-${spyId && spyId.replace('panel_', '') || 0}`} />}
+                    {showHelp && <ButtonHelp blockName={blockName || snakeCase(this.i18n(title)).split('_')[0]} />}
                 </div>
                 <div className='mdl-card__supporting-text' data-focus='panel-content'>
                     {children}


### PR DESCRIPTION
Misspelled a PropType ( :trollface: ) and reduced the help block name to the first word of the title instead of everything (I had a problem with a title like `Contacts (2)` where the number could obviously change).
Also adds a `blockName` prop to override the generated blockName (that doesn't include any spyId anymore)