### PR TITLE
Adding ref to decorated component

### DIFF
--- a/src/behaviours/store/connect.js
+++ b/src/behaviours/store/connect.js
@@ -90,6 +90,7 @@ export default function connectToStores(storesConfiguration, getState) {
                 const {props, state} = this;
                 return (
                     <DecoratedComponent
+                        ref='innerComponent'
                         {...props}
                         {...state}
                     />


### PR DESCRIPTION
## [[connectToStore] Title: Improving the connect to store]

### Description

Adding ref to decorated component, so it can be accessed from parent (for example, to get a value, or call a function)