### PR TITLE
change on advancedSearch - willMount action's call in option

### DIFF
--- a/src/page/search/advanced-search/index.js
+++ b/src/page/search/advanced-search/index.js
@@ -47,7 +47,7 @@ const AdvancedSearch = {
         return {
             action: undefined,
             backToTopComponent: BackToTopComponent,
-            callSearchOnMount : false,
+            callSearchOnMount : true,
             facetConfig: {},
             groupComponent: DefaultGroupComponent,
             hasBackToTop: true,

--- a/src/page/search/advanced-search/index.js
+++ b/src/page/search/advanced-search/index.js
@@ -47,6 +47,7 @@ const AdvancedSearch = {
         return {
             action: undefined,
             backToTopComponent: BackToTopComponent,
+            callSearchOnMount : false,
             facetConfig: {},
             groupComponent: DefaultGroupComponent,
             hasBackToTop: true,
@@ -69,6 +70,7 @@ const AdvancedSearch = {
     propTypes: {
         action: type('object'),
         backToTopComponent: type('func'),
+        callSearchOnMount : type('bool'),
         exportAction: type('func'),
         facetConfig: type('object'),
         groupComponent: type('func'),
@@ -111,7 +113,9 @@ const AdvancedSearch = {
             identifier: this.props.store.identifier,
             getSearchOptions: () => {return this.props.store.getValue.call(this.props.store); } // Binding the store in the function call
         });
-        this._action.search();
+        if(callSearchOnMount) {
+            this._action.search();
+        }
     },
     /**
     * Un-register the store listeners


### PR DESCRIPTION
## [AdvancedSearch] willMount action's call in option

### Description

The action's call during the will mount is now an option. This modifcation fix an issue when only one scope is selected.

Currently, the component does two call when we dispatch a scope. An unscoped call and a call with the good scope. 

Now, when the option is false the first isn't done.