### PR TITLE
Update memory-scroll.js

### DIFF
--- a/src/list/mixin/memory-scroll.js
+++ b/src/list/mixin/memory-scroll.js
@@ -15,6 +15,14 @@ let memoryMixin = {
             maxElements: this.props.perPage
         };
     },
+    
+    componentWillReceiveProps(nextProps) {
+        if(nextProps.perPage && nextProps.perPage !== this.props.perPage) {
+            this.setState({
+                maxElements: nextProps.perPage
+            });
+        }
+    },
 
     /**
      * Calculate the number of element to display in the memory list.


### PR DESCRIPTION
## [[memory-scroll] Title: fix perPage]

### Description
In listFor, when perPage is given after the first render, it is dismissed.