### PR TITLE
[Button/Menu] Adjusting button props

### DIFF
--- a/src/components/button/example/index.jsx
+++ b/src/components/button/example/index.jsx
@@ -32,29 +32,29 @@ const ButtonExample = React.createClass({
             <div>
                 <div style={this.flexContainer}>
                     <h4 style={this.flexItemTitle}>RIPPLE EFFECT</h4>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' handleOnClick={() => console.log(this)} onMouseOver={() => console.log('Mouse enter event')} /><br/><br/>Without ripple</div>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='colored' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>With ripple</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' onClick={() => console.log(this)} onMouseOver={() => console.log('Mouse enter event')} /><br/><br/>Without ripple</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='colored' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>With ripple</div>
                 </div>
 
                 <div style={this.flexContainer}>
                     <h4 style={this.flexItemTitle}>SIMPLE BUTTON</h4>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Button</div>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='primary' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Primary color</div>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='accent' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Accent color</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Button</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='primary' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Primary color</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='accent' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Accent color</div>
                 </div>
 
                 <div style={this.flexContainer}>
                     <h4 style={this.flexItemTitle}>FAB</h4>
-                    <div style={this.flexItem}><Button icon='add' type='button' shape='fab' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>FAB</div>
-                    <div style={this.flexItem}><Button icon='add' type='button' shape='fab' color='primary' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Primary color</div>
-                    <div style={this.flexItem}><Button icon='add' type='button' shape='fab' color='accent' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Accent color</div>
+                    <div style={this.flexItem}><Button icon='add' type='button' shape='fab' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>FAB</div>
+                    <div style={this.flexItem}><Button icon='add' type='button' shape='fab' color='primary' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Primary color</div>
+                    <div style={this.flexItem}><Button icon='add' type='button' shape='fab' color='accent' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Accent color</div>
                 </div>
 
                 <div style={this.flexContainer}>
                     <h4 style={this.flexItemTitle}>MINI-FAB</h4>
-                    <div style={this.flexItem}><Button icon='add' type='button' shape='mini-fab' handleOnClick={() => console.log(this)} /><br/><br/>Mini FAB</div>
-                    <div style={this.flexItem}><Button icon='add' type='button' shape='mini-fab' color='primary' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Primary color</div>
-                    <div style={this.flexItem}><Button icon='add' type='button' shape='mini-fab' color='accent' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>Accent color</div>
+                    <div style={this.flexItem}><Button icon='add' type='button' shape='mini-fab' onClick={() => console.log(this)} /><br/><br/>Mini FAB</div>
+                    <div style={this.flexItem}><Button icon='add' type='button' shape='mini-fab' color='primary' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Primary color</div>
+                    <div style={this.flexItem}><Button icon='add' type='button' shape='mini-fab' color='accent' hasRipple={true} onClick={() => console.log(this)} /><br/><br/>Accent color</div>
                 </div>
             </div>
         );

--- a/src/components/button/example/index.jsx
+++ b/src/components/button/example/index.jsx
@@ -32,7 +32,7 @@ const ButtonExample = React.createClass({
             <div>
                 <div style={this.flexContainer}>
                     <h4 style={this.flexItemTitle}>RIPPLE EFFECT</h4>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' handleOnClick={() => console.log(this)} /><br/><br/>Without ripple</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' handleOnClick={() => console.log(this)} onMouseOver={() => console.log('HELLOOOOO')} /><br/><br/>Without ripple</div>
                     <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='colored' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>With ripple</div>
                 </div>
 

--- a/src/components/button/example/index.jsx
+++ b/src/components/button/example/index.jsx
@@ -32,7 +32,7 @@ const ButtonExample = React.createClass({
             <div>
                 <div style={this.flexContainer}>
                     <h4 style={this.flexItemTitle}>RIPPLE EFFECT</h4>
-                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' handleOnClick={() => console.log(this)} onMouseOver={() => console.log('HELLOOOOO')} /><br/><br/>Without ripple</div>
+                    <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' handleOnClick={() => console.log(this)} onMouseOver={() => console.log('Mouse enter event')} /><br/><br/>Without ripple</div>
                     <div style={this.flexItem}><Button label='button.label' type='button' shape='raised' color='colored' hasRipple={true} handleOnClick={() => console.log(this)} /><br/><br/>With ripple</div>
                 </div>
 

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -126,7 +126,8 @@ class Button extends Component {
         // attribute doc : https://developer.mozilla.org/fr/docs/Web/HTML/Element/Button
         // be careful the way you declare your attribute names : https://developer.mozilla.org/fr/docs/Web/HTML/Element/Button
         const {className, disabled, formNoValidate, handleOnClick, icon, id, onClick, type, label, style, ...otherProps } = this.props;
-        const otherInputProps = { disabled, formNoValidate, onClick: handleOnClick ? handleOnClick : onClick, style, type }; //on click for legacy. Remove handleOnClick in v2
+        const {hasRipple, isJs, iconLibrary, ...rest} = this.props;
+        const otherInputProps = { disabled, formNoValidate, onClick: handleOnClick ? handleOnClick : onClick, style, type, ...rest }; //on click for legacy. Remove handleOnClick in v2
         const renderedClassName = `${className ? className : ''} ${::this._getComponentClassName()}`.trim();
         return (
             <button alt={this.i18n(label)} className={renderedClassName} data-focus='button-action' id={id} title={this.i18n(label)} {...otherInputProps} ref='materialButton'>

--- a/src/components/menu/example/index.jsx
+++ b/src/components/menu/example/index.jsx
@@ -10,9 +10,13 @@ const MyMenu = React.createClass({
         return [
             {
                 icon:'home',
+                route: '/',
                 onClick() {
-                    self.goHome();
-                }
+                    console.log('Home clicked')
+                },
+                onMouseOver() {
+                    console.log('Home clicked')
+                },
             },
             {
                 icon:'chat',
@@ -22,8 +26,9 @@ const MyMenu = React.createClass({
             },
             {
                 icon:'info',
+                route: '#component/Menu',
                 onClick() {
-                    window.location.href = '#component/Menu';
+                    console.log('information clicked');
                 }
             }
         ]

--- a/src/components/menu/example/index.jsx
+++ b/src/components/menu/example/index.jsx
@@ -15,7 +15,7 @@ const MyMenu = React.createClass({
                     console.log('Home clicked')
                 },
                 onMouseOver() {
-                    console.log('Home clicked')
+                    console.log('Mouse enter event is called')
                 },
             },
             {

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -25,29 +25,34 @@ function _renderItemsList(items, LinkComponent, navigate) {
 
 //Todo: refactor into component
 function _renderButton(menuButton, LinkComponent, navigate) {
+    menuButton.shape = 'icon';
+    menuButton.type = 'button';
+
     const buttonProps = {
-        option: 'link',
         shape: 'icon',
-        type: 'button',
-        ...menuButton
-    };
+        type: 'button'
+    }
+
+    const {route, option, ...otherProps} = menuButton;
+    const menuButtonProps = {...buttonProps, ...otherProps};
     let clickHandler;
+
     if(menuButton.route !== undefined) {
         //React router case
         if(LinkComponent){
             //Todo: check menButton onClick use
-            return <LinkComponent to={menuButton.route} style={{color: 'white'}}><Button {...buttonProps}/></LinkComponent>
+            return <LinkComponent to={menuButton.route} style={{color: 'white'}}><Button  {...menuButtonProps}/></LinkComponent>
         }
         //Backbone case
         clickHandler = () => {
             if(menuButton.onClick) menuButton.onClick();
             navigate(menuButton.route, true);
         };
-        return <Button {...buttonProps} onClick={clickHandler}/>
+        return <Button {...menuButtonProps} onClick={clickHandler}/>
 
     }
     //No route => Both the same treatement.
-    return <Button {...buttonProps} onClick={menuButton.onClick}/>
+    return <Button {...menuButtonProps} onClick={menuButton.onClick}/>
 }
 
 // default props


### PR DESCRIPTION
## [Button/Menu] Adjusting button props

### Description

Previously the given props didn't take the whole dom props' possibilities. 
Now it's more efficient and it can take props as onMouseEnter respecting the React 15 domain props. It prevents warning

If a project give a prop to a button and the prop isn't recognized by React as a legal DOM attribute/property React will throw a warning.

Please read the https://facebook.github.io/react/warnings/unknown-prop.html documentation.

> Fixes #1294 