### PR TITLE
Removing translate in displayText

### DIFF
--- a/src/components/display/text/index.js
+++ b/src/components/display/text/index.js
@@ -1,5 +1,4 @@
 import React, {PropTypes} from 'react';
-import {translate} from 'focus-core/translation';
 
 const defaultProps = {
     formatter: (data) => data
@@ -14,9 +13,8 @@ const propTypes = {
 
 //v2 : replace div by span
 function DisplayText({formatter, style, value}) {
-    const formattedValue = translate(formatter(value));
     return(
-        <div className={style}>{formattedValue}</div>
+        <div className={style}>{formatter(value)}</div>
     );
 }
 


### PR DESCRIPTION
Removing translate, since it is breaking input in consult mode.

@GuenoleK Why put it ? Mistake ?