### PR TITLE
Fixing store-change-behaviour

### DIFF
--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -68,6 +68,9 @@ const changeBehaviourMixin = {
     * Event handler for 'error' events coming from the stores.
     */
     _onError: function onFormErrorHandler(changeInfos) {
+        this.setState(this._getLoadingStateFromStores(), () => this._handleErrors(changeInfos)); // update errors after status
+    },
+    _handleErrors(){
         const errorState = this._getErrorStateFromStores();
         if (this.definitionPath) {
             // In case we have a definitionPath, we might want to trigger a setError on the corresponding field
@@ -85,7 +88,6 @@ const changeBehaviourMixin = {
                 }
             }
         }
-        this.setState(this._getLoadingStateFromStores()); // update status after errors
     },
     /**
     * Read


### PR DESCRIPTION
If the status is set in the state after the errors are set, it triggers a new render, so the errors are not displayed anymore.
It should be done after.
@GuenoleK  @TomGallon Any case it should not be the case ?