### PR TITLE
Add possibility to give the button type

### DIFF
--- a/src/components/icon-dropdown/index.js
+++ b/src/components/icon-dropdown/index.js
@@ -27,7 +27,8 @@ class Dropdown extends Component {
             iconLibrary: 'material'
         },
         shape: 'fab',
-        operationList: []
+        operationList: [],
+        buttonType: 'submit'
     };
 
     state = {
@@ -68,7 +69,7 @@ class Dropdown extends Component {
     }
 
     render() {
-        const {iconProps: {name, iconLibrary}, operationList, shape, openDirection} = this.props;
+        const {iconProps: {name, iconLibrary}, operationList, shape, openDirection, buttonType} = this.props;
         const {visible} = this.state;
         const id = this._htmlId;
         return (
@@ -79,6 +80,7 @@ class Dropdown extends Component {
                     icon={name}
                     iconLibrary={iconLibrary}
                     handleOnClick={this._handleIconClick.bind(this)}
+                    type={buttonType}
                     />
                 {visible &&
                     <div data-focus='dropdown-menu' data-position={openDirection} ref='dropdown'>


### PR DESCRIPTION
VISION needs a dropdown that does not propagate an event. I have added the possibility to give the button type to the dropdown component. I have kept a default prop for the button at "submit", so that it will not affect existing dropdowns.

## [[Component] Title: fix or new feature]

### Description

[Description of the issue fixed or the new feature]
[Screenshots if possible in case of a new feature]

### Patch [in case of a fix]

[Description of the fix]
> Fixes #ISSUE(S)_NUMBER

### Example [in case of a new feature]

```jsx
// Sample code
```
