### PR TITLE
Update inputs props

### DIFF
--- a/src/components/input/autocomplete-select/edit.js
+++ b/src/components/input/autocomplete-select/edit.js
@@ -213,34 +213,28 @@ class Autocomplete extends Component {
     };
 
     render () {
-        /**
-         * I think the following props are given by the high order Field Component.
-         * For me, we gotta pull out the non desired props
-         */
-        const {
-            onBadInput, domain, error, locale, isEdit, hasLabel, isRequired, validator, formatter, unformatter, FieldComponent, InputLabelComponent,
-            InputComponent, SelectComponent, TextComponent, DisplayComponent, options, labelSize, labelCellPosition, contentCellPosition, AutocompleteComponent,
-            AutocompleteSelectComponent, AutocompleteTextComponent, LabelComponent, ...otherProps
-        } = this.props;
-        const {customError, inputTimeout, keyName, keyResolver, labelName, placeholder, querySearcher, renderOptions, ...inputProps} = otherProps;
+        const { autoFocus, disabled, onKeyPress, maxLength, onFocus, onClick, customError: error, placeholder, renderOptions, ...otherProps }  = this.props;
         const {inputValue, isLoading} = this.state;
         const {_handleQueryFocus, _handleQueryKeyDown, _handleQueryChange} = this;
+        const inputProps =  {
+            autoFocus, disabled, onKeyPress, maxLength, onFocus, onClick,
+            onChange: _handleQueryChange, onFocus: _handleQueryFocus,
+            onKeyDown: _handleQueryKeyDown,
+            value: !inputValue ? '' : inputValue
+        };
+
         return (
             <div data-focus='autocomplete' data-id={this.autocompleteId}>
-                <div className={`mdl-textfield mdl-js-textfield${customError ? ' is-invalid' : ''}`} data-focus='input-text' ref='inputText'>
+                <div className={`mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`} data-focus='input-text' ref='inputText'>
                     <div data-focus='loading' data-loading={isLoading} className='mdl-progress mdl-js-progress mdl-progress__indeterminate' ref='loader'></div>
                     <input
                         className='mdl-textfield__input'
                         {...inputProps}
-                        onChange={_handleQueryChange}
-                        onFocus={_handleQueryFocus}
-                        onKeyDown={_handleQueryKeyDown}
                         ref='htmlInput'
                         type='text'
-                        value={!inputValue ? '' : inputValue}
                     />
                     <label className='mdl-textfield__label'>{this.i18n(placeholder)}</label>
-                    <span className='mdl-textfield__error'>{this.i18n(customError)}</span>
+                    <span className='mdl-textfield__error'>{this.i18n(error)}</span>
                 </div>
                 {renderOptions ? renderOptions.call(this) : this._renderOptions()}
             </div>

--- a/src/components/input/autocomplete-select/edit.js
+++ b/src/components/input/autocomplete-select/edit.js
@@ -213,7 +213,16 @@ class Autocomplete extends Component {
     };
 
     render () {
-        const {customError, inputTimeout, keyName, keyResolver, labelName, placeholder, querySearcher, renderOptions, ...inputProps} = this.props;
+        /**
+         * I think the following props are given by the high order Field Component.
+         * For me, we gotta pull out the non desired props
+         */
+        const {
+            onBadInput, domain, error, locale, isEdit, hasLabel, isRequired, validator, formatter, unformatter, FieldComponent, InputLabelComponent,
+            InputComponent, SelectComponent, TextComponent, DisplayComponent, options, labelSize, labelCellPosition, contentCellPosition, AutocompleteComponent,
+            AutocompleteSelectComponent, AutocompleteTextComponent, LabelComponent, ...otherProps
+        } = this.props;
+        const {customError, inputTimeout, keyName, keyResolver, labelName, placeholder, querySearcher, renderOptions, ...inputProps} = otherProps;
         const {inputValue, isLoading} = this.state;
         const {_handleQueryFocus, _handleQueryKeyDown, _handleQueryChange} = this;
         return (

--- a/src/components/input/autocomplete-select/edit.js
+++ b/src/components/input/autocomplete-select/edit.js
@@ -213,7 +213,7 @@ class Autocomplete extends Component {
     };
 
     render () {
-        const { autoFocus, onBlur, disabled, onKeyPress, maxLength, onFocus, onClick, customError: error, placeholder, renderOptions, ...otherProps }  = this.props;
+        const { autoFocus, onBlur, disabled, onKeyPress, maxLength, onFocus, onClick, customError, placeholder, renderOptions, ...otherProps }  = this.props;
         const {inputValue, isLoading} = this.state;
         const {_handleQueryFocus, _handleQueryKeyDown, _handleQueryChange} = this;
         const inputProps =  {
@@ -225,7 +225,7 @@ class Autocomplete extends Component {
 
         return (
             <div data-focus='autocomplete' data-id={this.autocompleteId}>
-                <div className={`mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`} data-focus='input-text' ref='inputText'>
+                <div className={`mdl-textfield mdl-js-textfield${customError ? ' is-invalid' : ''}`} data-focus='input-text' ref='inputText'>
                     <div data-focus='loading' data-loading={isLoading} className='mdl-progress mdl-js-progress mdl-progress__indeterminate' ref='loader'></div>
                     <input
                         className='mdl-textfield__input'
@@ -234,7 +234,7 @@ class Autocomplete extends Component {
                         type='text'
                     />
                     <label className='mdl-textfield__label'>{this.i18n(placeholder)}</label>
-                    <span className='mdl-textfield__error'>{this.i18n(error)}</span>
+                    <span className='mdl-textfield__error'>{this.i18n(customError)}</span>
                 </div>
                 {renderOptions ? renderOptions.call(this) : this._renderOptions()}
             </div>

--- a/src/components/input/autocomplete-select/edit.js
+++ b/src/components/input/autocomplete-select/edit.js
@@ -213,13 +213,13 @@ class Autocomplete extends Component {
     };
 
     render () {
-        const { autoFocus, disabled, onKeyPress, maxLength, onFocus, onClick, customError: error, placeholder, renderOptions, ...otherProps }  = this.props;
+        const { autoFocus, onBlur, disabled, onKeyPress, maxLength, onFocus, onClick, customError: error, placeholder, renderOptions, ...otherProps }  = this.props;
         const {inputValue, isLoading} = this.state;
         const {_handleQueryFocus, _handleQueryKeyDown, _handleQueryChange} = this;
         const inputProps =  {
             autoFocus, disabled, onKeyPress, maxLength, onFocus, onClick,
             onChange: _handleQueryChange, onFocus: _handleQueryFocus,
-            onKeyDown: _handleQueryKeyDown,
+            onKeyDown: _handleQueryKeyDown, onBlur,
             value: !inputValue ? '' : inputValue
         };
 

--- a/src/components/input/autocomplete-select/edit.js
+++ b/src/components/input/autocomplete-select/edit.js
@@ -237,7 +237,7 @@ class Autocomplete extends Component {
                         onKeyDown={_handleQueryKeyDown}
                         ref='htmlInput'
                         type='text'
-                        value={inputValue}
+                        value={!inputValue ? '' : inputValue}
                     />
                     <label className='mdl-textfield__label'>{this.i18n(placeholder)}</label>
                     <span className='mdl-textfield__error'>{this.i18n(customError)}</span>

--- a/src/components/input/autocomplete-text/edit.js
+++ b/src/components/input/autocomplete-text/edit.js
@@ -171,7 +171,7 @@ class AutocompleteTextEdit extends Component {
             <div data-focus='autocompleteText'>
                 <div className={`mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`} ref='materialInput'>
                     <div data-focus='loading' data-loading={isLoading} className='mdl-progress mdl-js-progress' ref='loader'/>
-                    <input onFocus={this.toggleHasFocus} onBlur={this.toggleHasFocus} className='mdl-textfield__input' type='text' value={inputValue} ref='inputText' onChange={::this.onQueryChange} showAtFocus={showAtFocus} emptyShowAll={emptyShowAll} {...otherProps} />
+                    <input onFocus={this.toggleHasFocus} onBlur={this.toggleHasFocus} className='mdl-textfield__input' type='text' value={!inputValue ? '' : inputValue} ref='inputText' onChange={::this.onQueryChange} showAtFocus={showAtFocus} emptyShowAll={emptyShowAll} {...otherProps} />
                     <label className="mdl-textfield__label">{this.i18n(placeholder)}</label>
                     <span className="mdl-textfield__error" ref='errorMessage'>{this.i18n(error)}</span>
                 </div>

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -68,10 +68,10 @@ class InputText extends Component {
      * @override
     */
     render() {
-        const { autoFocus, disabled, formatter, unformatter, maxLength, onFocus, onClick, onKeyDown, onKeyPress, error, name, placeholder, style, value: rawValue, size, type} = this.props;
+        const { autoFocus, onBlur, disabled, formatter, unformatter, maxLength, onFocus, onClick, onKeyDown, onKeyPress, error, name, placeholder, style, value: rawValue, size, type} = this.props;
         const value = formatter(rawValue, MODE);
         const pattern = error ? 'hasError' : null; //add pattern to overide mdl error style when displaying an focus error.
-        const inputProps =  { autoFocus, disabled, onKeyDown,onKeyPress, maxLength, onFocus, onClick, id: name, onChange: this._handleInputChange, pattern, size, type, value: !value ? '' : value};
+        const inputProps =  { autoFocus, disabled, onKeyDown, onKeyPress, onBlur, maxLength, onFocus, onClick, id: name, onChange: this._handleInputChange, pattern, size, type, value: !value ? '' : value};
         const cssClass = `mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`;
         return (
             <div className={cssClass} data-focus='input-text' ref='inputText' style={style}>

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -71,7 +71,7 @@ class InputText extends Component {
         const { autoFocus, disabled, formatter, unformatter, maxLength, onFocus, onClick, onKeyDown, onKeyPress, error, name, placeholder, style, value: rawValue, size, type} = this.props;
         const value = formatter(rawValue, MODE);
         const pattern = error ? 'hasError' : null; //add pattern to overide mdl error style when displaying an focus error.
-        const inputProps =  { autoFocus, disabled, onKeyDown,onKeyPress, maxLength, onFocus, onClick, id: name, onChange: this._handleInputChange, pattern, size, type, value };
+        const inputProps =  { autoFocus, disabled, onKeyDown,onKeyPress, maxLength, onFocus, onClick, id: name, onChange: this._handleInputChange, pattern, size, type, value: !value ? '' : value};
         const cssClass = `mdl-textfield mdl-js-textfield${error ? ' is-invalid' : ''}`;
         return (
             <div className={cssClass} data-focus='input-text' ref='inputText' style={style}>

--- a/src/components/input/text/index.js
+++ b/src/components/input/text/index.js
@@ -68,7 +68,7 @@ class InputText extends Component {
      * @override
     */
     render() {
-        const { autoFocus, disabled, formatter, maxLength, onFocus, onClick, onKeyDown, onKeyPress, error, name, placeholder, style, value: rawValue, size, type} = this.props;
+        const { autoFocus, disabled, formatter, unformatter, maxLength, onFocus, onClick, onKeyDown, onKeyPress, error, name, placeholder, style, value: rawValue, size, type} = this.props;
         const value = formatter(rawValue, MODE);
         const pattern = error ? 'hasError' : null; //add pattern to overide mdl error style when displaying an focus error.
         const inputProps =  { autoFocus, disabled, onKeyDown,onKeyPress, maxLength, onFocus, onClick, id: name, onChange: this._handleInputChange, pattern, size, type, value };


### PR DESCRIPTION
## Update inputs props

### Description

This PR fixes the fact warnings from React 15 were sent because of unknow HTML attributes.
It's now managed on InputText, AutocompletSelect and AutocompleteText as it was done on 2.1.1 for the Button component.