### PR TITLE
Clean up and fix validation behaviour

### DIFF
--- a/src/common/form/mixin/validation-behaviour.js
+++ b/src/common/form/mixin/validation-behaviour.js
@@ -15,7 +15,7 @@ function _fieldsValidation() {
         //validate only the reference elements which have valid function
         if (isFunction(refElt.validate) || isFunction(refElt._validate)) {
             let validationRes = isFunction(refElt.validate) ? refElt.validate() : refElt._validate();
-            if (validationRes !== undefined || validationRes !== true) {
+            if (validationRes !== undefined && validationRes !== true) {
                 isValid = false;
             }
         }

--- a/src/common/form/mixin/validation-behaviour.js
+++ b/src/common/form/mixin/validation-behaviour.js
@@ -13,10 +13,10 @@ function _fieldsValidation() {
     for (let inptKey in this.refs) {
         const refElt = this.refs[inptKey];
         //validate only the reference elements which have valid function
-        if(isFunction(refElt.validate) || isFunction(refElt._validate)) {
+        if (isFunction(refElt.validate) || isFunction(refElt._validate)) {
             let validationRes = isFunction(refElt.validate) ? refElt.validate() : refElt._validate();
-            if(validationRes !== undefined || validationRes !== true) {
-                isValid = false, 
+            if (validationRes !== undefined || validationRes !== true) {
+                isValid = false;
             }
         }
     }
@@ -27,7 +27,7 @@ function _fieldsValidation() {
  * @return {true} -  If the custom validation is defined.
  */
 function _customValidation() {
-    if(this.customValidation) {
+    if (this.customValidation) {
         return this.customValidation();
     }
     return true;

--- a/src/common/form/mixin/validation-behaviour.js
+++ b/src/common/form/mixin/validation-behaviour.js
@@ -9,21 +9,18 @@ let assign = require('object-assign');
 */
 function _fieldsValidation() {
     let validationMap = {};
+    let isValid = true;
     for (let inptKey in this.refs) {
-        //validate only the reference elements which have valide function
-        if(isFunction(this.refs[inptKey].validate)) {
-            let validationRes = this.refs[inptKey].validate();
-            if(validationRes !== undefined) {
-                assign(validationMap, {
-                    [inptKey]: validationRes
-                });
+        const refElt = this.refs[inptKey];
+        //validate only the reference elements which have valid function
+        if(isFunction(refElt.validate) || isFunction(refElt._validate)) {
+            let validationRes = isFunction(refElt.validate) ? refElt.validate() : refElt._validate();
+            if(validationRes !== undefined || validationRes !== true) {
+                isValid = false, 
             }
         }
     }
-    if(isEmpty(validationMap)) {
-        return true;
-    }
-    return false;
+    return isValid;
 }
 /**
  * Custom validation of the field.
@@ -43,19 +40,8 @@ function _validate() {
     return this._fieldsValidation() && this._customValidation();
 }
 
-/**
- * Validate the form
- * @deprecated
- * @return {object} - The validation  result.
- */
-function validate() {
-    console.warn('This function will be deprecated in the version 0.6.0 the validate function should be custom for the project, instead call this._validate');
-    return this._validate();
-}
-
 module.exports = {
     _fieldsValidation,
     _customValidation,
-    _validate,
-    validate
+    _validate
 };

--- a/src/utils/is-react-class-component.js
+++ b/src/utils/is-react-class-component.js
@@ -7,7 +7,7 @@ export const isReactClassComponent = ComponentToTest => {
     return false;
   }
   return typeof prototype.render === 'function';
-}
+};
 
 export const addRefToPropsIfNotPure = (Component, props, ref) => (isReactClassComponent(Component) ? {...props, ref} : props);
 


### PR DESCRIPTION
Rewrite validation
Clean up deprecated code

### Description
It is a pain to use custom component with validation inside a form :
if the component extends validationBehvaiour, this._validate or validate return a boolean value, like true, and not undefined.
So, if a form is calling it, the form will be invalid
