### PR TITLE
[built-in-components] fix InputLabelComponen

### DIFF
--- a/src/common/field/mixin/built-in-components.js
+++ b/src/common/field/mixin/built-in-components.js
@@ -252,7 +252,7 @@ const fieldBuiltInComponentsMixin = {
             error: error,
             onChange: this.onInputChange
         };
-        const finalBuildedProps = addRefToPropsIfNotPure(this.props.FieldComponent, buildedProps, INPUT);
+        const finalBuildedProps = addRefToPropsIfNotPure(FieldComponent, buildedProps, INPUT);
         return <FieldComponent {...finalBuildedProps} />;
     }
 };


### PR DESCRIPTION
## [built-in-components] fix InputLabelComponent 

### Description

Fix dans la cas où on utilise InputLabelComponent de built-in-components.

```jsx
    foofield: {
      domain: "DO_BAR",
      InputLabelComponent: Baz
    }
```
