### PR TITLE
Fixing issue with header

### DIFF
--- a/src/application/popin/index.js
+++ b/src/application/popin/index.js
@@ -31,7 +31,7 @@ const Overlay = React.createClass({
     * @private
     */
     _restoreBodyOverflow() {
-        document.body.style['overflow-y'] = 'auto';
+        document.body.style['overflow-y'] = 'visible';
     },
     /**
     * Component will unmount event handler.


### PR DESCRIPTION
The header is not fixed if opening and closing a popin
When scrolling, the header disappear

I think visible is the default value for overflow, not auto.