### PR TITLE
Tooltip doesn't take className well

### DIFF
--- a/src/components/tooltip/index.js
+++ b/src/components/tooltip/index.js
@@ -35,7 +35,7 @@ class Tooltip extends PureComponent {
     buildClassname = () => {
         const {isLarge, position} = this.props;
         let tooltipLarge = isLarge === true ? ' mdl-tooltip--large' : '';
-        return `mdl-tooltip mdl-tooltip--${position}${tooltipLarge}`;
+        return ` mdl-tooltip mdl-tooltip--${position}${tooltipLarge}`;
     }
 
     render() {


### PR DESCRIPTION
Fix issue #1399

Generated classname concat both custom and own classes without space between em