### PR TITLE
[Autocomplete] Label not cleared after setting value to null

### DIFF
--- a/src/components/input/autocomplete-select/edit.js
+++ b/src/components/input/autocomplete-select/edit.js
@@ -82,7 +82,7 @@ class Autocomplete extends Component {
         }
 
         if (this.props.clearOnNullValue && this.props.clearOnNullValue === true && value === null && this.state.inputValue !== null) {
-            this.setState({inputValue: null});
+            this.setState({inputValue: ''});
         }
     }
 


### PR DESCRIPTION
Fix issue #1405

If inputValue is set to null it is not passed to the input. It must be set to an empty string in order to work properly.
