### PR TITLE
[SelectCheckbox] fix onChange behavior

### DIFF
--- a/src/components/input/select-checkbox/index.js
+++ b/src/components/input/select-checkbox/index.js
@@ -22,7 +22,8 @@ class SelectCheckbox extends Component {
         value: PropTypes.array,
         valueKey: PropTypes.string,
         labelKey: PropTypes.string,
-        onChange: PropTypes.func
+        onChange: PropTypes.func,
+        legacyOnChange: PropTypes.bool
     };
 
     /**
@@ -33,7 +34,8 @@ class SelectCheckbox extends Component {
         value: [], // selected values list
         valueKey: 'value', // key for the displayed value
         labelKey: 'label', // key for the displayed label
-        onChange: undefined
+        onChange: undefined,
+        legacyOnChange: false
     };
 
     /**
@@ -75,7 +77,11 @@ class SelectCheckbox extends Component {
         }
 
         if (this.props.onChange) {
-            this.props.onChange(selectedValues);
+            if (this.props.legacyOnChange) {
+                this.props.onChange({ key, newStatus });
+            } else {
+                this.props.onChange(selectedValues);
+            }
             return;
         }
 

--- a/src/components/input/select-checkbox/index.js
+++ b/src/components/input/select-checkbox/index.js
@@ -1,17 +1,22 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component, PropTypes } from 'react';
 import Checkbox from '../checkbox';
 import Translation from '../../../behaviours/translation';
-import {pull} from 'lodash/array';
+import { pull } from 'lodash/array';
 
+/**
+ * SelectCheckbox component.
+ */
 @Translation
 class SelectCheckbox extends Component {
-    static defaultProps = {
-        values: [], // all values
-        value: [], // selected values list
-        valueKey: 'value', // key for the displayed value
-        labelKey: 'label' // key for the displayed label
-    };
 
+    /**
+     * Display name.
+     */
+    static displayName = 'SelectCheckbox';
+
+    /**
+     * PropTypes.
+     */
     static propTypes = {
         values: PropTypes.array,
         value: PropTypes.array,
@@ -20,13 +25,31 @@ class SelectCheckbox extends Component {
         onChange: PropTypes.func
     };
 
+    /**
+     * Default props.
+     */
+    static defaultProps = {
+        values: [], // all values
+        value: [], // selected values list
+        valueKey: 'value', // key for the displayed value
+        labelKey: 'label', // key for the displayed label
+        onChange: undefined
+    };
+
+    /**
+     * Initial state.
+     */
     state = {
         selectedValues: this.props.value
     };
 
+    /**
+     * React componentWillReceiveProps hook.
+     * @param {object} newProps new props.
+     */
     componentWillReceiveProps(newProps) {
         if (newProps) {
-            this.setState({selectedValues: newProps.value});
+            this.setState({ selectedValues: newProps.value });
         }
     }
 
@@ -54,7 +77,7 @@ class SelectCheckbox extends Component {
         } else {
             pull(selectedValues, key);
         }
-        this.setState({value: selectedValues});
+        this.setState({ value: selectedValues });
     }
 
     /**
@@ -83,6 +106,10 @@ class SelectCheckbox extends Component {
         });
     }
 
+    /**
+     * Render.
+     * @return {ReactElement} markup.
+     */
     render() {
         return (
             <div data-focus='select-checkbox'>
@@ -91,7 +118,5 @@ class SelectCheckbox extends Component {
         );
     }
 }
-
-SelectCheckbox.displayName = 'SelectCheckbox';
 
 export default SelectCheckbox;

--- a/src/components/input/select-checkbox/index.js
+++ b/src/components/input/select-checkbox/index.js
@@ -69,23 +69,17 @@ class SelectCheckbox extends Component {
      * @param  {[type]} newStatus the new status
      */
     _handleCheckboxChange(key, newStatus) {
-        const selectedValues = this.state.selectedValues;
-        if (newStatus) {
-            selectedValues.push(key);
+        const selectedValues = newStatus
+            ? this.state.selectedValues.concat([key])
+            : this.state.selectedValues.filter(elt => elt !== key);
+
+        if (this.props.onChange && this.props.legacyOnChange) {
+            this.props.onChange(key, newStatus);
+        } else if (this.props.onChange) {
+            this.props.onChange(selectedValues);
         } else {
-            pull(selectedValues, key);
+            this.setState({ value: selectedValues });
         }
-
-        if (this.props.onChange) {
-            if (this.props.legacyOnChange) {
-                this.props.onChange(key, newStatus);
-            } else {
-                this.props.onChange(selectedValues);
-            }
-            return;
-        }
-
-        this.setState({ value: selectedValues });
     }
 
     /**

--- a/src/components/input/select-checkbox/index.js
+++ b/src/components/input/select-checkbox/index.js
@@ -67,16 +67,18 @@ class SelectCheckbox extends Component {
      * @param  {[type]} newStatus the new status
      */
     _handleCheckboxChange(key, newStatus) {
-        if (this.props.onChange) {
-            this.props.onChange(key, newStatus);
-            return;
-        }
         const selectedValues = this.state.selectedValues;
         if (newStatus) {
             selectedValues.push(key);
         } else {
             pull(selectedValues, key);
         }
+
+        if (this.props.onChange) {
+            this.props.onChange(selectedValues);
+            return;
+        }
+
         this.setState({ value: selectedValues });
     }
 

--- a/src/components/input/select-checkbox/index.js
+++ b/src/components/input/select-checkbox/index.js
@@ -78,7 +78,7 @@ class SelectCheckbox extends Component {
 
         if (this.props.onChange) {
             if (this.props.legacyOnChange) {
-                this.props.onChange({ key, newStatus });
+                this.props.onChange(key, newStatus);
             } else {
                 this.props.onChange(selectedValues);
             }


### PR DESCRIPTION
Fix issue #1412 

## Current behaviour

`onChange` is called with two parameters : `key` and `newStatus`

## New behaviour

- `onChange` is now called by default with the newly selected values as an array of key
- A new option `legacyOnChange` is available to get the old behavior

### Caution

The `field-component-behaviour._wrappedOnChange` method will truncate the second parameter. Therefore legacy `onChange `will not work when inside a `fieldFor`

