### PR TITLE
[StoreChangeBehavior] Fix storeChange should not trigger onChange

### DIFF
--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -15,7 +15,7 @@ const storeMixin = {
             return this.getStateFromStore();
         }
 
-        const newState = {};
+        let newState = {};
         this.stores.forEach((storeConf) => {
             storeConf.properties.forEach((property) => {
                 newState[property] = storeConf.store[`get${capitalize(property)}`]();

--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -164,9 +164,9 @@ const storeMixin = {
         if (!store || !store.definition || !store.definition[property]) {
             throw new Error(`You ${action} a property : ${property} in your store subscription for ${store.name || store.identifier} which is not in your definition : ${Object.keys(store.definition)}`);
         }
-        store[`${action}${capitalize(property)}ChangeListener`](this._onChange);
-        store[`${action}${capitalize(property)}ErrorListener`](this._onError);
-        store[`${action}${capitalize(property)}StatusListener`](this._onStatus);
+        store[`${action}${capitalize(property)}ChangeListener`](this._onStoreChange);
+        store[`${action}${capitalize(property)}ErrorListener`](this._onStoreError);
+        store[`${action}${capitalize(property)}StatusListener`](this._onStoreStatus);
     },
 
     /**

--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -122,6 +122,7 @@ const storeMixin = {
         if (this.stores) {
             this.stores.forEach((storeConf) => {
                 storeConf.properties.forEach((property) => {
+                    if (!storeConf.store || !storeConf.store.definition || !storeConf.store.definition[property]) {
                     this._addRemoveSingleListener('add', storeConf.store, property);
                 });
             });

--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -44,8 +44,9 @@ const storeMixin = {
             defaultData = Object.keys(this.definition).reduce((acc, key) => ({ ...acc, [key]: null }), {});
         }
 
-        // We want to pick only some nodes
+        // We want to pick only some nodes & reference nodes
         if (filterNodes.length > 0) {
+            filterNodes = filterNodes.concat(this.referenceNames || []);
             newState = pick(newState, filterNodes);
             defaultData = pick(defaultData, filterNodes);
         }
@@ -112,7 +113,9 @@ const storeMixin = {
             return this.computeEntityFromStoresData(data);
         }
 
-        const entity = { reference: {} };
+        const entity = {
+            reference: {}
+        };
         for (let key in data) {
             if (this.referenceNames && this.referenceNames.includes(key)) {
                 entity.reference[key] = data[key];

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -24,21 +24,17 @@ const changeBehaviourMixin = {
     * @param  {object} changeInfos - An object containing all the event informations, without the data.
     * @return {function} - An override function can be called.
     */
-    _displayMessageOnChange: function displayMessageOnChange(changeInfos) {
+    _displayMessageOnChange(changeInfos) {
         if (this.displayMessageOnChange) {
             return this.displayMessageOnChange(changeInfos);
         }
+
         if (changeInfos && changeInfos.status && changeInfos.status.name) {
             switch (changeInfos.status.name) {
-                /* case 'loading':
-                Focus.message.addInformationMessage('detail.loading');
-                break;
+                case 'loading':
                 case 'loaded':
-                Focus.message.addSuccessMessage('detail.loaded');
-                break;
                 case 'saving':
-                Focus.message.addInformationMessage('detail.saving');
-                break;*/
+                    break;
                 case 'saved':
                     //Maybe the action result or the event should have a caller notion.
                     message.addSuccessMessage('detail.saved');
@@ -52,30 +48,39 @@ const changeBehaviourMixin = {
             }
         }
     },
-    _afterChange: function afterChangeWrapper(changeInfos) {
+	/**
+    * After change informations.
+    * You can override this method using afterChange function.
+    * @param {object} changeInfos - All informations relative to the change.
+    * @returns {undefined} -  The return value is the callback.
+    * @param {object} changeInfos The changing informations.
+    * @returns {undefined} The return value is the callback.
+    */
+    _afterChange(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._afterChangeWrapped(changeInfos);
         } else {
             this._pendingActionsChangeBehaviourMixin.push(() => this._afterChangeWrapped(changeInfos));
         }
     },
-    /**
-    * After change informations.
-    * You can override this method using afterChange function.
-    * @param {object} changeInfos - All informations relative to the change.
-    * @returns {undefined} -  The return value is the callback.
-    */
-    _afterChangeWrapped: function afterChangeFormWrapped(changeInfos) {
+    
+    _afterChangeWrapped(changeInfos) {
         if (this.afterChange) {
             return this.afterChange(changeInfos);
         }
+
         //If there is no callerId in the event, the display message does not have any sens.
         //Other component responding to the store property change does not need to react on it.
         if (changeInfos && changeInfos.informations && changeInfos.informations.callerId && this._identifier === changeInfos.informations.callerId) {
             return this._displayMessageOnChange(changeInfos);
         }
-
     },
+
+	/**
+    * Event handler for 'change' events coming from the stores
+    * @param {object} changeInfos - The changing informations.
+    * @param {object} changeInfos The changing informations.
+    */
     _onChange: function _onChangeWrapper(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._onChangeWrapped(changeInfos);
@@ -83,17 +88,19 @@ const changeBehaviourMixin = {
             this._pendingActionsChangeBehaviourMixin.push(() => this._onChangeWrapped(changeInfos));
         }
     },
-    /**
-    * Event handler for 'change' events coming from the stores
-    * @param {object} changeInfos - The changing informations.
-    */
-    _onChangeWrapped: function onFormStoreChangeHandler(changeInfos) {
+    
+    _onChangeWrapped(changeInfos) {
         let onChange = this.props.onChange || this.onChange;
         if (onChange) {
             onChange.call(this, changeInfos);
         }
-        this.setState(this._getStateFromStores(changeInfos.property), () => this._afterChange(changeInfos));
+
+        this.setState(this._getStateFromStores(), () => this._afterChange(changeInfos));
     },
+	/**
+    * Event handler for 'error' events coming from the stores.
+    * @param {object} changeInfos The changing informations.
+    */
     _onError: function _onErrorWrapper(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._onErrorWrapped(changeInfos);
@@ -101,12 +108,14 @@ const changeBehaviourMixin = {
             this._pendingActionsChangeBehaviourMixin.push(() => this._onErrorWrapped(changeInfos));
         }
     },
-    /**
-    * Event handler for 'error' events coming from the stores.
-    */
-    _onErrorWrapped: function onFormErrorHandler(changeInfos) {
+    
+    _onErrorWrapped(changeInfos) {
         this.setState(this._getLoadingStateFromStores(), () => this._handleErrors(changeInfos)); // update errors after status
     },
+
+    /**
+     * Handle errors.
+     */
     _handleErrors() {
         const errorState = this._getErrorStateFromStores();
         if (this.definitionPath) {
@@ -126,6 +135,12 @@ const changeBehaviourMixin = {
             }
         }
     },
+	/**
+    * Read
+    * @param  {[type]} changeInfos [description]
+    * @return {[type]}             [description]
+    * Read.
+    */
     _onStatus: function _onStatusWrapper(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._onStatusWrapped(changeInfos);
@@ -133,18 +148,15 @@ const changeBehaviourMixin = {
             this._pendingActionsChangeBehaviourMixin.push(() => this._onStatusWrapped(changeInfos));
         }
     },
-    /**
-    * Read
-    * @param  {[type]} changeInfos [description]
-    * @return {[type]}             [description]
-    */
-    _onStatusWrapped: function _onStatus(changeInfos) {
+    
+    _onStatusWrapped(changeInfos) {
         if (this._getEntity) {
             this.setState({ ...this._getEntity(), ...this._getLoadingStateFromStores() });
         } else {
             this.setState(this._getLoadingStateFromStores());
         }
-
     }
+
 };
+
 export default changeBehaviourMixin;

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -1,20 +1,30 @@
 import message from 'focus-core/message';
 import { changeMode } from 'focus-core/application';
-import { keys } from 'lodash';
 
+/**
+ * Behavior to update state according to stores.
+ */
 const changeBehaviourMixin = {
-    getInitialState: function getInitialState() {
+
+    /** @inheritdoc */
+    getInitialState() {
         return {};
     },
+
+    /** @inheritdoc */
     componentWillMount() {
         this._isMountedChangeBehaviourMixin = false;
         this._pendingActionsChangeBehaviourMixin = [];
     },
+
+    /** @inheritdoc */
     componentDidMount() {
         this._isMountedChangeBehaviourMixin = true;
         this._pendingActionsChangeBehaviourMixin.forEach(func => func());
         this._pendingActionsChangeBehaviourMixin = [];
     },
+
+    /** @inheritdoc */
     componentWillUnmount() {
         this._isMountedChangeBehaviourMixin = false;
     },
@@ -48,13 +58,12 @@ const changeBehaviourMixin = {
             }
         }
     },
+
     /**
     * After change informations.
     * You can override this method using afterChange function.
     * @param {object} changeInfos - All informations relative to the change.
     * @returns {undefined} -  The return value is the callback.
-    * @param {object} changeInfos The changing informations.
-    * @returns {undefined} The return value is the callback.
     */
     _afterChange(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
@@ -63,7 +72,13 @@ const changeBehaviourMixin = {
             this._pendingActionsChangeBehaviourMixin.push(() => this._afterChangeWrapped(changeInfos));
         }
     },
-    
+
+    /**
+    * After change informations.
+    * You can override this method using afterChange function.
+    * @param {object} changeInfos - All informations relative to the change.
+    * @returns {undefined} -  The return value is the callback.
+    */
     _afterChangeWrapped(changeInfos) {
         if (this.afterChange) {
             return this.afterChange(changeInfos);
@@ -88,7 +103,12 @@ const changeBehaviourMixin = {
             this._pendingActionsChangeBehaviourMixin.push(() => this._onChangeWrapped(changeInfos));
         }
     },
-    
+
+    /**
+    * Event handler for 'change' events coming from the stores
+    * @param {object} changeInfos - The changing informations.
+    * @param {object} changeInfos The changing informations.
+    */
     _onChangeWrapped(changeInfos) {
         let onChange = this.props.onChange || this.onChange;
         if (onChange) {
@@ -96,16 +116,6 @@ const changeBehaviourMixin = {
         }
 
         this.setState(this._getStateFromStores(), () => this._afterChange(changeInfos));
-    },
-    /**
-    * Read.
-    */
-    _onStoreStatus() {
-        if (this._getEntity) {
-            this.setState({ ...this._getEntity(), ...this._getLoadingStateFromStores() });
-        } else {
-            this.setState(this._getLoadingStateFromStores());
-        }
     },
 
     /**
@@ -119,7 +129,11 @@ const changeBehaviourMixin = {
             this._pendingActionsChangeBehaviourMixin.push(() => this._onErrorWrapped(changeInfos));
         }
     },
-    
+
+    /**
+    * Event handler for 'error' events coming from the stores.
+    * @param {object} changeInfos The changing informations.
+    */
     _onErrorWrapped(changeInfos) {
         this.setState(this._getLoadingStateFromStores(), () => this._handleErrors(changeInfos)); // update errors after status
     },
@@ -134,10 +148,10 @@ const changeBehaviourMixin = {
             for (let key in errorState) {
                 // Let's find that corresponding field, considering that the ref might not directly be 'storeNode.fieldName', but in fact 'entityPath.fieldName'
                 if (this.refs) {
-                    const refKey = keys(this.refs).filter(candidateRef => {
+                    const refKey = Object.keys(this.refs).find(candidateRef => {
                         const candidate = candidateRef.replace(`${this.definitionPath}.`, ''); // Remove the 'definitionPath.'
                         return candidate === key.match(/([^\.]*)$/)[0] // Look for the 'fieldName' part of 'storeNode.fieldName'
-                    })[0];
+                    });
 
                     if (refKey) { // If we found it, then bingo
                         this.refs[refKey].setError(errorState[key]);
@@ -145,28 +159,32 @@ const changeBehaviourMixin = {
                 }
             }
         }
-		}
     },
+
 	/**
     * Read
     * @param  {[type]} changeInfos [description]
-    * @return {[type]}             [description]
-    * Read.
     */
-    _onStatus: function _onStatusWrapper(changeInfos) {
+    _onStatus(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._onStatusWrapped(changeInfos);
         } else {
             this._pendingActionsChangeBehaviourMixin.push(() => this._onStatusWrapped(changeInfos));
         }
     },
-    
+
+	/**
+    * Read
+    * @param  {[type]} changeInfos [description]
+    */
     _onStatusWrapped(changeInfos) {
         if (this._getEntity) {
             this.setState({ ...this._getEntity(), ...this._getLoadingStateFromStores() });
         } else {
             this.setState(this._getLoadingStateFromStores());
 
-};
+        }
+    }
+}
 
 export default changeBehaviourMixin;

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -115,7 +115,7 @@ const changeBehaviourMixin = {
             onStoreChange.call(this, changeInfos);
         }
 
-        this.setState(this._getStateFromStores(changeInfos.property), () => this._afterStoreChange(changeInfos));
+        this.setState(this._getStateFromStores([changeInfos.property]), () => this._afterStoreChange(changeInfos));
     },
 
     /**

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -1,6 +1,7 @@
 import message from 'focus-core/message';
 import { changeMode } from 'focus-core/application';
 import reduce from 'lodash/collection/reduce';
+import { keys } from 'lodash';
 
 const changeBehaviourMixin = {
     getInitialState: function getInitialState() {
@@ -48,7 +49,7 @@ const changeBehaviourMixin = {
             }
         }
     },
-	/**
+    /**
     * After change informations.
     * You can override this method using afterChange function.
     * @param {object} changeInfos - All informations relative to the change.
@@ -76,12 +77,12 @@ const changeBehaviourMixin = {
         }
     },
 
-	/**
+    /**
     * Event handler for 'change' events coming from the stores
     * @param {object} changeInfos - The changing informations.
     * @param {object} changeInfos The changing informations.
     */
-    _onChange: function _onChangeWrapper(changeInfos) {
+    _onChange(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._onChangeWrapped(changeInfos);
         } else {
@@ -97,11 +98,22 @@ const changeBehaviourMixin = {
 
         this.setState(this._getStateFromStores(), () => this._afterChange(changeInfos));
     },
-	/**
+    /**
+    * Read.
+    */
+    _onStoreStatus() {
+        if (this._getEntity) {
+            this.setState({ ...this._getEntity(), ...this._getLoadingStateFromStores() });
+        } else {
+            this.setState(this._getLoadingStateFromStores());
+        }
+    },
+
+    /**
     * Event handler for 'error' events coming from the stores.
     * @param {object} changeInfos The changing informations.
     */
-    _onError: function _onErrorWrapper(changeInfos) {
+    _onError(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
             this._onErrorWrapped(changeInfos);
         } else {
@@ -134,6 +146,7 @@ const changeBehaviourMixin = {
                 }
             }
         }
+		}
     },
 	/**
     * Read
@@ -154,8 +167,6 @@ const changeBehaviourMixin = {
             this.setState({ ...this._getEntity(), ...this._getLoadingStateFromStores() });
         } else {
             this.setState(this._getLoadingStateFromStores());
-        }
-    }
 
 };
 

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -65,9 +65,9 @@ const changeBehaviourMixin = {
     * @param {object} changeInfos - All informations relative to the change.
     * @returns {undefined} -  The return value is the callback.
     */
-    _afterChange(changeInfos) {
+    _afterStoreChange(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
-            this._afterChangeWrapped(changeInfos);
+            this._afterStoreChangeWrapped(changeInfos);
         } else {
             this._pendingActionsChangeBehaviourMixin.push(() => this._afterChangeWrapped(changeInfos));
         }
@@ -79,7 +79,7 @@ const changeBehaviourMixin = {
     * @param {object} changeInfos - All informations relative to the change.
     * @returns {undefined} -  The return value is the callback.
     */
-    _afterChangeWrapped(changeInfos) {
+    _afterStoreChangeWrapped(changeInfos) {
         if (this.afterChange) {
             return this.afterChange(changeInfos);
         }
@@ -96,11 +96,11 @@ const changeBehaviourMixin = {
     * @param {object} changeInfos - The changing informations.
     * @param {object} changeInfos The changing informations.
     */
-    _onChange(changeInfos) {
+    _onStoreChange(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
-            this._onChangeWrapped(changeInfos);
+            this._onStoreChangeWrapped(changeInfos);
         } else {
-            this._pendingActionsChangeBehaviourMixin.push(() => this._onChangeWrapped(changeInfos));
+            this._pendingActionsChangeBehaviourMixin.push(() => this._onStoreChangeWrapped(changeInfos));
         }
     },
 
@@ -109,24 +109,24 @@ const changeBehaviourMixin = {
     * @param {object} changeInfos - The changing informations.
     * @param {object} changeInfos The changing informations.
     */
-    _onChangeWrapped(changeInfos) {
-        let onChange = this.props.onChange || this.onChange;
-        if (onChange) {
-            onChange.call(this, changeInfos);
+    _onStoreChangeWrapped(changeInfos) {
+        let onStoreChange = this.props.onStoreChange || this.onStoreChange;
+        if (onStoreChange) {
+            onStoreChange.call(this, changeInfos);
         }
 
-        this.setState(this._getStateFromStores(), () => this._afterChange(changeInfos));
+        this.setState(this._getStateFromStores(changeInfos.property), () => this._afterStoreChange(changeInfos));
     },
 
     /**
     * Event handler for 'error' events coming from the stores.
     * @param {object} changeInfos The changing informations.
     */
-    _onError(changeInfos) {
+    _onStoreError(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
-            this._onErrorWrapped(changeInfos);
+            this._onStoreErrorWrapped(changeInfos);
         } else {
-            this._pendingActionsChangeBehaviourMixin.push(() => this._onErrorWrapped(changeInfos));
+            this._pendingActionsChangeBehaviourMixin.push(() => this._onStoreErrorWrapped(changeInfos));
         }
     },
 
@@ -134,7 +134,7 @@ const changeBehaviourMixin = {
     * Event handler for 'error' events coming from the stores.
     * @param {object} changeInfos The changing informations.
     */
-    _onErrorWrapped(changeInfos) {
+    _onStoreErrorWrapped(changeInfos) {
         this.setState(this._getLoadingStateFromStores(), () => this._handleErrors(changeInfos)); // update errors after status
     },
 
@@ -165,11 +165,11 @@ const changeBehaviourMixin = {
     * Read
     * @param  {[type]} changeInfos [description]
     */
-    _onStatus(changeInfos) {
+    _onStoreStatus(changeInfos) {
         if (this._isMountedChangeBehaviourMixin) {
-            this._onStatusWrapped(changeInfos);
+            this._onStoreStatusWrapped(changeInfos);
         } else {
-            this._pendingActionsChangeBehaviourMixin.push(() => this._onStatusWrapped(changeInfos));
+            this._pendingActionsChangeBehaviourMixin.push(() => this._onStoreStatusWrapped(changeInfos));
         }
     },
 
@@ -177,7 +177,7 @@ const changeBehaviourMixin = {
     * Read
     * @param  {[type]} changeInfos [description]
     */
-    _onStatusWrapped(changeInfos) {
+    _onStoreStatusWrapped(changeInfos) {
         if (this._getEntity) {
             this.setState({ ...this._getEntity(), ...this._getLoadingStateFromStores() });
         } else {

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -1,6 +1,5 @@
 import message from 'focus-core/message';
 import { changeMode } from 'focus-core/application';
-import reduce from 'lodash/collection/reduce';
 import { keys } from 'lodash';
 
 const changeBehaviourMixin = {
@@ -134,15 +133,15 @@ const changeBehaviourMixin = {
             // In case we have a definitionPath, we might want to trigger a setError on the corresponding field
             for (let key in errorState) {
                 // Let's find that corresponding field, considering that the ref might not directly be 'storeNode.fieldName', but in fact 'entityPath.fieldName'
-                const ref = reduce(this.refs, (acc, value, candidateRef) => {
-                    const candidate = candidateRef.replace(`${this.definitionPath}.`, ''); // Remove the 'definitionPath.'
-                    if (candidate === key.match(/([^\.]*)$/)[0]) { // Look for the 'fieldName' part of 'storeNode.fieldName'
-                        acc = value;
+                if (this.refs) {
+                    const refKey = keys(this.refs).filter(candidateRef => {
+                        const candidate = candidateRef.replace(`${this.definitionPath}.`, ''); // Remove the 'definitionPath.'
+                        return candidate === key.match(/([^\.]*)$/)[0] // Look for the 'fieldName' part of 'storeNode.fieldName'
+                    })[0];
+
+                    if (refKey) { // If we found it, then bingo
+                        this.refs[refKey].setError(errorState[key]);
                     }
-                    return acc;
-                }, null);
-                if (ref) { // If we found it, then bingo
-                    ref.setError(errorState[key]);
                 }
             }
         }


### PR DESCRIPTION
Fix issue #1411 

### Description

`StoreChangeBehavior::storeChange` call a `onChange` method giving it the `changeInfos`.
If a component is used within a `fieldFor` then a generic `onChange` is given. 

### Patch 

1. The method used by StoreChangeBehavior will be renamed to `storeOnChange` to ensure no collision with forms' `onChange` methods.
2. There is a typo with `getDefaultStoreData`

### Enhancement

Add a hook on `onStoreError` to retrieve more easily error on nodes
