### PR TITLE
Clear message center if there is no more message

### DIFF
--- a/src/components/message-center/index.js
+++ b/src/components/message-center/index.js
@@ -50,6 +50,8 @@ class MessageCenter extends Component {
     _checkQueue = () => {
         if (this.queuedNotifications.length > 0) {
             this.showSnackbar(this.queuedNotifications.shift());
+        } else {
+            this.showSnackbar({ message: '' });
         }
     };
 


### PR DESCRIPTION
To avoid the message center to stay at the bottom of the page when there is no more messages and when the last message was in multiple lines, clear the last message when the closing animation has ended.