### PR TITLE
InputDate - Reverting react-date-picker to 3.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "better-npm-run test",
         "test:watch": "better-npm-run test-watch",
         "postinstall": "node scripts/mdl-variables-copy.js",
-        "prepare": "npm run build",
+        "prepublishOnly": "npm run build",
         "lint": "eslint src --ext .js,.jsx --ignore-pattern __tests__ --ignore-pattern example --ignore-pattern awesomplete",
         "lint:error": "eslint src --ext .js,.jsx --ignore-pattern __tests__ --ignore-pattern example --ignore-pattern awesomplete --quiet",
         "fix-lint": "eslint  src/** --ext .js,.jsx --fix --ignore-pattern __tests__ --ignore-pattern example --ignore-pattern awesomplete"
@@ -61,7 +61,7 @@
     },
     "homepage": "https://github.com/KleeGroup/focus-components",
     "peerDependencies": {
-        "focus-core": "2.2.0-beta2",
+        "focus-core": "2.2.0-beta3",
         "material-design-lite": "1.3.0",
         "moment": "2.18.1",
         "react": "15.4.2",
@@ -71,7 +71,7 @@
     "dependencies": {
         "closest": "0.0.1",
         "lodash": "3.10.1",
-        "react-date-picker": "5.3.28",
+        "react-date-picker": "3.1.10",
         "react-lazyload": "2.2.7",
         "uuid": "3.1.0"
     },
@@ -81,7 +81,7 @@
         "better-npm-run": "0.1.0",
         "enzyme": "2.9.1",
         "eslint-config-focus": "0.6.0",
-        "focus-core": "2.2.0-beta2",
+        "focus-core": "2.2.0-beta3",
         "jest-cli": "21.0.2",
         "jsdom": "11.2.0",
         "material-design-lite": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "focus-components",
-    "version": "2.2.0-beta1",
+    "version": "2.2.0-beta2",
     "description": "Focus component repository.",
     "main": "index.js",
     "scripts": {

--- a/src/components/input/date/index.js
+++ b/src/components/input/date/index.js
@@ -2,7 +2,7 @@
 import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import moment from 'moment';
-import DatePicker from 'react-date-picker/lib/MonthView';
+import DatePicker from 'react-date-picker';
 import isArray from 'lodash/lang/isArray';
 import uniqueId from 'lodash/utility/uniqueId';
 import closest from 'closest';
@@ -182,7 +182,7 @@ class InputDate extends Component {
      * Handle calendar changes.
      * @memberOf InputDate
      */
-    _onDropDownChange = (text, { dateMoment: date }) => {
+    _onDropDownChange = (text, date) => {
         if (date._isValid) {
             this.setState({ displayPicker: false }, () => {
                 const correctedDate = moment.utc(date).add(moment(date).utcOffset(), 'minutes').toISOString(); // Add UTC offset to get right ISO string


### PR DESCRIPTION
The new version has a different visual.
Reverting to avoid visual regression