### PR TITLE
[StoreChangeBehavior] add initial call to `_getStateFromStores` in will mount

### DIFF
--- a/src/common/form/mixin/reference-behaviour.js
+++ b/src/common/form/mixin/reference-behaviour.js
@@ -4,20 +4,12 @@ import builtInActionReferenceLoader from 'focus-core/reference/built-in-action';
 import difference from 'lodash/array/difference';
 
 const referenceMixin = {
+
     /** @inheritdoc */
-    /*  getDefaultProps: function getReferenceDefaultProps(){
-    return {*/
-    /**
-    * Array which contains all the reference lists.
-    * If the referenceNames are set into the object, they are set into the default props.
-    * @type {Array}
-    */
-    /*  referenceNames: this.referenceNames || []
-    };
-    },*/
     getInitialState() {
         return { reference: {} };
     },
+
     /**
     * Build actions associated to the reference.
     */
@@ -27,9 +19,11 @@ const referenceMixin = {
         }
         this.action.loadReference = builtInActionReferenceLoader(referenceNames);
     },
+
     _loadReference() {
         return this.action.loadReference();
     },
+
     /**
     * Build the reference names and set the store into the application.
     */
@@ -56,12 +50,14 @@ const referenceMixin = {
             });
         }
     },
+
     componentWillReceiveProps({ referenceNames }) {
         if (referenceNames) {
             this._buildReference(referenceNames, this.referenceNames);
             this._loadReference();
         }
     },
+
     /**
     * Build store and actions related to the reference.
     */
@@ -70,10 +66,12 @@ const referenceMixin = {
         this._buildReferenceActions(referenceNames);
         this.referenceNames = referenceNames;
     },
+
     componentDidMount() {
         // Calling at didMount and not willMount to be coherent with old loadReference from form
         this._loadReference();
     },
+
     /** @inheritdoc */
     componentWillMount() {
         const referenceNames = this.props.referenceNames || this.referenceNames;

--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -26,6 +26,13 @@ const storeMixin = {
     componentWillMount() {
         //These listeners are registered before the mounting because they are not correlated to the DOM.
         this._registerListeners();
+
+        if (this.stores === undefined) {
+            this.stores = [];
+        }
+
+        const newState = this._getStateFromStores();
+        this.setState(newState);
     },
 
     /** @inheritdoc */

--- a/src/common/mixin/store-behaviour.js
+++ b/src/common/mixin/store-behaviour.js
@@ -1,5 +1,4 @@
 import assign from 'object-assign';
-
 import capitalize from 'lodash/string/capitalize';
 import isArray from 'lodash/lang/isArray';
 import isObject from 'lodash/lang/isObject';
@@ -15,6 +14,13 @@ import storeChangeBehaviour from './store-change-behaviour';
 const storeMixin = {
 
     mixins: [storeChangeBehaviour],
+
+    /** @inheritdoc */
+    getDefaultProps() {
+        return {
+            useDefaultStoreData: false
+        };
+    },
 
     /** @inheritdoc */
     componentWillMount() {

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -12,6 +12,14 @@ const changeBehaviourMixin = {
     },
 
     /** @inheritdoc */
+    getDefaultProps() {
+        return {
+            // Smart state update push into state only the updated node
+            useSmartStateUpdate: false
+        };
+    },
+
+    /** @inheritdoc */
     componentWillMount() {
         this._isMountedChangeBehaviourMixin = false;
         this._pendingActionsChangeBehaviourMixin = [];
@@ -115,7 +123,12 @@ const changeBehaviourMixin = {
             onStoreChange.call(this, changeInfos);
         }
 
-        this.setState(this._getStateFromStores([changeInfos.property]), () => this._afterStoreChange(changeInfos));
+        let filterNodes = [];
+        if (this.props.useSmartStateUpdate) {
+            filterNodes = filterNodes.concat([changeInfos.property]);
+        }
+
+        this.setState(this._getStateFromStores(filterNodes), () => this._afterStoreChange(changeInfos));
     },
 
     /**

--- a/src/common/mixin/store-change-behaviour.js
+++ b/src/common/mixin/store-change-behaviour.js
@@ -12,14 +12,6 @@ const changeBehaviourMixin = {
     },
 
     /** @inheritdoc */
-    getDefaultProps() {
-        return {
-            // Smart state update push into state only the updated node
-            useSmartStateUpdate: false
-        };
-    },
-
-    /** @inheritdoc */
     componentWillMount() {
         this._isMountedChangeBehaviourMixin = false;
         this._pendingActionsChangeBehaviourMixin = [];
@@ -123,12 +115,7 @@ const changeBehaviourMixin = {
             onStoreChange.call(this, changeInfos);
         }
 
-        let filterNodes = [];
-        if (this.props.useSmartStateUpdate) {
-            filterNodes = filterNodes.concat([changeInfos.property]);
-        }
-
-        this.setState(this._getStateFromStores(filterNodes), () => this._afterStoreChange(changeInfos));
+        this.setState(this._getStateFromStores([changeInfos.property]), () => this._afterStoreChange(changeInfos));
     },
 
     /**


### PR DESCRIPTION
## StoreChangeBehavior

### Description

The new feature to push into store only the updated node removes an edge cases that is exploited.
It should be deactivated by default to avoid breaking changes.

### Patch 

Add a call to `_getStateFromStores` within mixin willMount
