### PR TITLE
[FormMixin] Validation - unnecessary named export

### DIFF
--- a/src/common/form/mixin/validation-behaviour.js
+++ b/src/common/form/mixin/validation-behaviour.js
@@ -39,11 +39,6 @@ function _validate() {
     return this._fieldsValidation() && this._customValidation();
 }
 
-export {
-    _fieldsValidation,
-    _customValidation,
-    _validate
-}
 export default {
     _fieldsValidation,
     _customValidation,


### PR DESCRIPTION
named export isn't necessary here, we're exporting a mixin