### PR TITLE
Add iconLibrary options to content-actions

### DIFF
--- a/src/application/content-actions/index.js
+++ b/src/application/content-actions/index.js
@@ -47,48 +47,43 @@ const ContentActions = {
         this.setState(this._getStateFromStore());
     },
 
+    /**
+     * Render a fab component.
+     * @param {object} fab Fab.
+     * @returns {JSXElement} Component.
+     */
+    renderFabAction(fab) {
+        if (isArray(fab.action)) {
+            return (
+                <Dropdown
+                    iconProps={{ name: fab.icon, iconLibrary: fab.iconLibrary }}
+                    operationList={fab.action}
+                    shape='fab'
+                />
+            );
+        } else {
+            return (
+                <Button
+                    handleOnClick={fab.action}
+                    icon={fab.icon}
+                    iconLibrary={fab.iconLibrary}
+                    label={fab.label}
+                    style={{ className: fab.className }}
+                    shape='fab'
+                    type='button'
+                />
+            );
+        }
+    },
+
     /** @inheritdoc */
     render() {
         const { actions: { primary, secondary } } = this.state;
         return (
             <div className={this._getStyleClassName()} data-focus='content-actions'>
-                {primary.map((primary) => {
-                    if (Array.isArray(primary.action)) {
-                        return (
-                            <Dropdown
-                                iconProps={{ name: primary.icon, iconLibrary: primary.iconLibrary }}
-                                operationList={primary.action}
-                                shape='fab'
-                            />
-                        );
-                    } else {
-                        return (
-                            <Button
-                                handleOnClick={primary.action}
-                                icon={primary.icon}
-                                iconLibrary={primary.iconLibrary}
-                                label={primary.label}
-                                shape='fab'
-                                style={{ className: primary.className }}
-                                type='button'
-                            />
-                        );
-                    }
-                })}
-                {isArray(secondary) && (
-                    <Dropdown
-                        iconProps={{ name: 'more_vert' }}
-                        operationList={secondary}
-                        shape='fab'
-                    />
-                )}
-                {isObject(secondary) && (
-                    <Dropdown
-                        iconProps={{ name: secondary.icon || 'more_vert', iconLibrary: secondary.iconLibrary }}
-                        operationList={secondary.action}
-                        shape='fab'
-                    />
-                )}
+                {primary.map((action) => this.renderFabAction(action))}
+                {isArray(secondary) && this.renderFabAction({ action: secondary })}
+                {isObject(secondary) && this.renderFabAction(secondary)}
             </div>
         );
     }

--- a/src/application/content-actions/index.js
+++ b/src/application/content-actions/index.js
@@ -1,3 +1,6 @@
+// Libs
+import isArray from 'lodash/lang/isArray';
+import isObject from 'lodash/lang/isObject';
 // Dependencies
 import builder from 'focus-core/component/builder';
 // Stores
@@ -9,19 +12,24 @@ import Button from '../../components/button';
 import { component as Dropdown } from '../../common/select-action';
 
 const ContentActions = {
+
     mixins: [stylableBehaviour],
-    /** @inheriteddoc */
+
+    /** @inheritdoc */
     getInitialState() {
         return this._getStateFromStore();
     },
-    /** @inheriteddoc */
+
+    /** @inheritdoc */
     componentWillMount() {
         applicationStore.addActionsChangeListener(this._handleComponentChange);
     },
-    /** @inheriteddoc */
+
+    /** @inheritdoc */
     componentWillUnmount() {
         applicationStore.removeActionsChangeListener(this._handleComponentChange);
     },
+
     /**
      * Get state from store
      * @return {Object} actions extracted from the store
@@ -31,29 +39,56 @@ const ContentActions = {
             actions: applicationStore.getActions() || { primary: [], secondary: [] }
         };
     },
+
     /**
      * Component change handler
      */
     _handleComponentChange() {
         this.setState(this._getStateFromStore());
     },
-    /** @inheriteddoc */
+
+    /** @inheritdoc */
     render() {
-        const { actions } = this.state;
+        const { actions: { primary, secondary } } = this.state;
         return (
             <div className={this._getStyleClassName()} data-focus='content-actions'>
-                {actions.primary.map((primary) => {
+                {primary.map((primary) => {
                     if (Array.isArray(primary.action)) {
                         return (
-                            <Dropdown iconProps={{ name: primary.icon }} operationList={primary.action} shape='fab' />
+                            <Dropdown
+                                iconProps={{ name: primary.icon, iconLibrary: primary.iconLibrary }}
+                                operationList={primary.action}
+                                shape='fab'
+                            />
                         );
                     } else {
                         return (
-                            <Button handleOnClick={primary.action} icon={primary.icon} label={primary.label} shape='fab' style={{ className: primary.className }} type='button' />
+                            <Button
+                                handleOnClick={primary.action}
+                                icon={primary.icon}
+                                iconLibrary={primary.iconLibrary}
+                                label={primary.label}
+                                shape='fab'
+                                style={{ className: primary.className }}
+                                type='button'
+                            />
                         );
                     }
                 })}
-                <Dropdown iconProps={{ name: 'more_vert' }} operationList={actions.secondary} shape='fab' />
+                {isArray(secondary) && (
+                    <Dropdown
+                        iconProps={{ name: 'more_vert' }}
+                        operationList={secondary}
+                        shape='fab'
+                    />
+                )}
+                {isObject(secondary) && (
+                    <Dropdown
+                        iconProps={{ name: secondary.icon || 'more_vert', iconLibrary: secondary.iconLibrary }}
+                        operationList={secondary.action}
+                        shape='fab'
+                    />
+                )}
             </div>
         );
     }

--- a/src/application/content-actions/index.js
+++ b/src/application/content-actions/index.js
@@ -1,5 +1,4 @@
 // Libs
-import isArray from 'lodash/lang/isArray';
 import isObject from 'lodash/lang/isObject';
 // Dependencies
 import builder from 'focus-core/component/builder';
@@ -48,42 +47,55 @@ const ContentActions = {
     },
 
     /**
-     * Render a fab component.
+     * Render a list fab component.
      * @param {object} fab Fab.
      * @returns {JSXElement} Component.
      */
-    renderFabAction(fab) {
-        if (isArray(fab.action)) {
+    renderFabListAction(fab) {
+        if (Array.isArray(fab.action) && fab.action.length > 0) {
+            const { icon, iconLibrary, action, ...otherProps } = fab;
             return (
                 <Dropdown
-                    iconProps={{ name: fab.icon, iconLibrary: fab.iconLibrary }}
-                    operationList={fab.action}
+                    iconProps={{ name: icon, iconLibrary }}
+                    operationList={action}
                     shape='fab'
-                />
-            );
-        } else {
-            return (
-                <Button
-                    handleOnClick={fab.action}
-                    icon={fab.icon}
-                    iconLibrary={fab.iconLibrary}
-                    label={fab.label}
-                    style={{ className: fab.className }}
-                    shape='fab'
-                    type='button'
+                    {...otherProps}
                 />
             );
         }
     },
 
+    /**
+     * Render a fab component.
+     * @param {object} fab Fab.
+     * @returns {JSXElement} Component.
+     */
+    renderFabAction(fab) {
+        const { action, className, icon, iconLibrary, label, ...otherProps } = fab;
+        return (
+            <Button
+                key={`header-action-${label}`}
+                className={className}
+                handleOnClick={action}
+                icon={icon}
+                iconLibrary={iconLibrary}
+                label={label}
+                shape='fab'
+                type='button'
+                {...otherProps}
+            />
+        );
+    },
+
     /** @inheritdoc */
     render() {
         const { actions: { primary, secondary } } = this.state;
+
         return (
             <div className={this._getStyleClassName()} data-focus='content-actions'>
                 {primary.map((action) => this.renderFabAction(action))}
-                {isArray(secondary) && this.renderFabAction({ action: secondary })}
-                {isObject(secondary) && this.renderFabAction(secondary)}
+                {Array.isArray(secondary) && this.renderFabListAction({ action: secondary })}
+                {isObject(secondary) && this.renderFabListAction(secondary)}
             </div>
         );
     }

--- a/src/application/content-actions/index.js
+++ b/src/application/content-actions/index.js
@@ -93,7 +93,7 @@ const ContentActions = {
 
         return (
             <div className={this._getStyleClassName()} data-focus='content-actions'>
-                {primary.map((action) => this.renderFabAction(action))}
+                {primary.map((action) => action && Array.isArray(action.action) ? this.renderFabListAction(action) : this.renderFabAction(action))}
                 {Array.isArray(secondary) && this.renderFabListAction({ action: secondary })}
                 {isObject(secondary) && this.renderFabListAction(secondary)}
             </div>

--- a/src/common/select-action/index.js
+++ b/src/common/select-action/index.js
@@ -1,72 +1,70 @@
+// Libs
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
+import uuid from 'uuid';
+import 'material-design-lite/material';
+// Dependencies
 import builder from 'focus-core/component/builder';
 import { translate } from 'focus-core/translation';
-import uuid from 'uuid';
+// Components
 import Button from '../../components/button';
-import 'material-design-lite/material';
 
 const Dropdown = {
 
-    /**
-    * Display name.
-    */
+    /** DisplayName. */
     displayName: 'Dropdown',
-    /**
-    * Default props.
-    * @returns {object} Defauilt props.
-    */
-    getDefaultProps() {
-        return {
-            position: 'right',
-            iconProps: {
-                name: 'more_vert'
-            },
-            shape: 'icon',
-            operationList: []
-        };
-    },
-    /**
-    * Scope property validation.
-    * @type {Object}
-    */
+
+    /** @inheritdoc */
     propTypes: {
-        position: PropTypes.string,
-        iconProps: PropTypes.object,
+        iconLibrary: PropTypes.string,
+        iconProps: PropTypes.shape({
+            name: PropTypes.string,
+            iconLibrary: PropTypes.string
+        }),
         operationList: PropTypes.array,
+        position: PropTypes.string,
         shape: PropTypes.string
     },
-    /**
-     * Component will mount
-     */
+
+    /** @inheritdoc */
+    getDefaultProps() {
+        return {
+            iconProps: {
+                name: 'more_vert',
+                iconLibrary: undefined
+            },
+            operationList: [],
+            position: 'right',
+            shape: 'icon'
+        };
+    },
+
+    /** @inheritdoc */
     componentWillMount() {
         this._htmlId = uuid.v4();
     },
-    /**
-    * Called when component is mounted.
-    */
+
+    /** @inheritdoc */
     componentDidMount() {
         if (0 !== this.props.operationList.length && ReactDOM.findDOMNode(this.refs.dropdown)) {
             componentHandler.upgradeElement(ReactDOM.findDOMNode(this.refs.dropdown));
         }
     },
-    /**
-     * Component will receive props.
-     * @param {Object} nextProps the next props
-     */
+
+    /** @inheritdoc */
     componentWillReceiveProps(nextProps) {
         if (0 !== nextProps.operationList.length && ReactDOM.findDOMNode(this.refs.dropdown)) {
             componentHandler.upgradeElement(ReactDOM.findDOMNode(this.refs.dropdown));
         }
     },
-    /**
-    * Called before component is unmounted.
-    */
+
+    /** @inheritdoc */
     componentWillUnmount() {
         if (0 !== this.props.operationList.length && ReactDOM.findDOMNode(this.refs.dropdown)) {
             componentHandler.downgradeElements(ReactDOM.findDOMNode(this.refs.dropdown));
         }
     },
+
     /**
     * Handle action on selected item.
     * @param {function} action Action to call
@@ -82,19 +80,19 @@ const Dropdown = {
             }
         };
     },
-    /**
-    * Render the component.
-    * @returns  {XML} Htm code.
-    */
+
+    /** @inheritdoc */
     render() {
         const { iconProps, operationList, position, shape } = this.props;
         const id = this._htmlId;
+
         if (0 === operationList.length) {
             return null;
         }
+
         return (
             <div>
-                <Button icon={iconProps.name} id={id} isJs shape={shape} />
+                <Button icon={iconProps.name} iconLibrary={iconProps.iconLibrary} id={id} isJs shape={shape} />
                 <ul className={`mdl-menu mdl-menu--bottom-${position} mdl-js-menu mdl-js-ripple-effect`} htmlFor={id} ref='dropdown'>
                     {operationList.map((operation, idx) => {
                         return (
@@ -110,10 +108,5 @@ const Dropdown = {
 };
 
 const { mixin, component } = builder(Dropdown);
-export default {
-    mixin, component
-}
-export {
-    mixin,
-    component
-}
+export default { mixin, component };
+export { mixin, component };

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -11,12 +11,20 @@ const RIPPLE_EFFECT = 'mdl-js-ripple-effect';
 
 @MDBehaviour('materialButton', 'MaterialButton')
 @Translation
+/**
+ * Button component.
+ */
 class Button extends Component {
 
+    /** DisplayName. */
     static displayName = 'Button';
 
+    /** PropTypes. */
     static propTypes = {
+        className: PropTypes.string,
         color: PropTypes.oneOf([undefined, 'colored', 'primary', 'accent']),
+        disabled: PropTypes.bool,
+        formNoValidate: PropTypes.bool,
         handleOnClick: PropTypes.func, //to remove in V2
         hasRipple: PropTypes.bool,
         id: PropTypes.string,
@@ -26,17 +34,27 @@ class Button extends Component {
         isLoading: PropTypes.bool,
         label: PropTypes.string,
         onClick: PropTypes.func,
+        processLabel: PropTypes.string,
         shape: PropTypes.oneOf([undefined, 'raised', 'fab', 'icon', 'mini-fab']),
         type: PropTypes.oneOf(['submit', 'button'])
     };
 
+    /** DefaultProps. */
     static defaultProps = {
+        className: '',
+        color: undefined,
+        disabled: false,
+        formNoValidate: false,
+        handleOnClick: undefined,
         hasRipple: false,
         icon: null,
         iconLibrary: 'material',
         id: '',
         isJs: false,
+        isLoading: false,
         label: '',
+        onClick: undefined,
+        processLabel: '',
         shape: 'raised',
         type: 'submit'
     };
@@ -98,7 +116,7 @@ class Button extends Component {
      * @return {Component} - Component button.
      */
     renderPressedButton() {
-        return (<button>Loading...</button>);
+        return (<button>{'Loading...'}</button>);
     }
 
     /**
@@ -109,11 +127,11 @@ class Button extends Component {
         const { icon, iconLibrary } = this.props;
         switch (iconLibrary) {
             case 'material':
-                return <i className='material-icons'>{icon}</i>;
+                return (<i className='material-icons'>{icon}</i>);
             case 'font-awesome':
-                return <i className={`fa fa-${icon}`} />;
+                return (<i className={`fa fa-${icon}`} />);
             case 'font-custom':
-                return <span className={`icon-${icon}`} />;
+                return (<span className={`icon-${icon}`} />);
             default:
                 return null;
         }
@@ -127,9 +145,13 @@ class Button extends Component {
         const { isLoading, label, processLabel, shape } = this.props;
 
         if (label && 'fab' !== shape && 'icon' !== shape && 'mini-fab' !== shape && (!isLoading || !processLabel)) {
-            return <span data-focus='button-label'>{this.i18n(label)}</span>;
+            return (
+                <span data-focus='button-label'>{this.i18n(label)}</span>
+            );
         } else if (processLabel && 'fab' !== shape && 'icon' !== shape && 'mini-fab' !== shape && isLoading) {
-            return <span data-focus='button-label'>{this.i18n(processLabel)}</span>
+            return (
+                <span data-focus='button-label'>{this.i18n(processLabel)}</span>
+            );
         }
         return null;
     }
@@ -155,20 +177,36 @@ class Button extends Component {
     render() {
         // attribute doc : https://developer.mozilla.org/fr/docs/Web/HTML/Element/Button
         // be careful the way you declare your attribute names : https://developer.mozilla.org/fr/docs/Web/HTML/Element/Button
-        const { className, disabled, formNoValidate, handleOnClick, icon, id, onClick, type, label, style, hasRipple, isJs, iconLibrary, isLoading, ...rest } = this.props;
+        const { className, disabled, formNoValidate, handleOnClick, icon, id, onClick, type, label, style, isLoading, ...rest } = this.props;
         const onClickFunc = handleOnClick ? handleOnClick : onClick;
         const otherInputProps = filterProps({ disabled, formNoValidate, style, type, ...rest }); //on click for legacy. Remove handleOnClick in v2
 
         if (onClickFunc) {
             otherInputProps.onClick = event => this._wrappedOnClick(event, onClickFunc);
         }
-        const renderedClassName = `${className ? className : ''} ${::this._getComponentClassName()}`.trim();
-        
+        const renderedClassName = `${className} ${this._getComponentClassName()}`.trim();
+
         return (
-            <button alt={this.i18n(label)} className={renderedClassName} data-focus='button-action' data-saving={isLoading} id={id} disabled={isLoading} title={this.i18n(label)} {...otherInputProps} ref='materialButton'>
-                {icon && ::this._renderIcon()}
-                {::this._renderLabel()}
-                {isLoading && <div className='mdl-spinner mdl-spinner--single-color mdl-js-spinner is-active' data-focus='double-action-button-spinner' ref='double-action-button-spinner' />}
+            <button
+                alt={this.i18n(label)}
+                className={renderedClassName}
+                data-focus='button-action'
+                data-saving={isLoading}
+                disabled={isLoading}
+                id={id}
+                ref='materialButton'
+                title={this.i18n(label)}
+                {...otherInputProps}
+            >
+                {icon && this._renderIcon()}
+                {this._renderLabel()}
+                {isLoading && (
+                    <div
+                        className='mdl-spinner mdl-spinner--single-color mdl-js-spinner is-active'
+                        data-focus='double-action-button-spinner'
+                        ref='double-action-button-spinner'
+                    />
+                )}
             </button>
         );
     }

--- a/src/components/icon-dropdown/index.js
+++ b/src/components/icon-dropdown/index.js
@@ -66,8 +66,10 @@ class Dropdown extends Component {
     }
 
     render() {
-        const { iconProps: { name, iconLibrary }, operationList, shape, openDirection, buttonType } = this.props;
+        const { name: defaultName, iconLibrary: defaultIconLibrary } = Dropdown.defaultProps.iconProps;
+        const { iconProps: { name = defaultName, iconLibrary = defaultIconLibrary }, operationList, shape, openDirection, buttonType } = this.props;
         const { visible } = this.state;
+
         return (
             <div data-focus='icon-dropdown' ref='parent'>
                 <Button

--- a/src/components/layout/header-actions.js
+++ b/src/components/layout/header-actions.js
@@ -25,18 +25,18 @@ const subActionType = PropTypes.arrayOf(PropTypes.shape({
 
 /** Action type. */
 const actionType = PropTypes.oneOfType([
-    { // Icon action
+    PropTypes.shape({ // Icon action
         label: PropTypes.string.isRequired,
         action: PropTypes.func.isRequired,
         icon: PropTypes.string.isRequired,
         iconLibrary: PropTypes.string,
         className: PropTypes.string
-    },
-    { // Dropdown action
+    }),
+    PropTypes.shape({ // Dropdown action
         icon: PropTypes.string,
         iconLibrary: PropTypes.string,
         action: subActionType.isRequired
-    }
+    })
 ]);
 
 /** Proptypes validation for HeaderActions. */
@@ -53,13 +53,15 @@ const propTypes = {
 /**
  * Render a list fab component.
  * @param {object} fab Fab.
+ * @param {number} idx Index. 
  * @returns {JSXElement} Component.
  */
-function renderFabListAction(fab) {
+function renderFabListAction(fab, idx) {
     if (Array.isArray(fab.action) && fab.action.length > 0) {
         const { icon, iconLibrary, action, ...otherProps } = fab;
         return (
             <Dropdown
+                key={`header-action-${idx}`}
                 iconProps={{ name: icon, iconLibrary }}
                 operationList={action}
                 shape='fab'
@@ -98,11 +100,11 @@ function renderFabAction(fab) {
 const HeaderActions = ({ actions: { primary, secondary }, ...otherProps }) => {
     return (
         <div data-focus='header-actions' {...filterProps(otherProps)}>
-            {primary.map((action) => {
-                return action && Array.isArray(action.action) ? renderFabListAction(action) : renderFabAction(action)
+            {primary.map((action, idx) => {
+                return action && Array.isArray(action.action) ? renderFabListAction(action, idx) : renderFabAction(action)
             })}
-            {Array.isArray(secondary) && renderFabListAction({ action: secondary })}
-            {isObject(secondary) && renderFabListAction(secondary)}
+            {Array.isArray(secondary) && renderFabListAction({ action: secondary }, 0)}
+            {isObject(secondary) && renderFabListAction(secondary, 0)}
         </div>
     );
 };

--- a/src/components/layout/header-actions.js
+++ b/src/components/layout/header-actions.js
@@ -1,58 +1,24 @@
 // Libs
 import React, { Component } from 'react';
 import isObject from 'lodash/lang/isObject';
+
 // Stores
 import applicationStore from 'focus-core/application/built-in-store';
 // Components
 import Button from '../../components/button';
 import Dropdown from '../../components/icon-dropdown';
+import storeConnect from '../../behaviours/store/connect';
 
 /**
 * HeaderActions component.
 */
+@storeConnect([
+    { store: applicationStore, properties: ['actions'] }
+], () => ({ actions: applicationStore.getActions() || { primary: [], secondary: [] } }))
 class HeaderActions extends Component {
 
     /** Display name. */
     static displayName = 'HeaderActions';
-
-    /**
-     * Constructor.
-     * @param {object} props Props.
-     */
-    constructor(props) {
-        super(props);
-
-        this.state = this._getStateFromStore();
-
-        this._handleComponentChange = this._handleComponentChange.bind(this);
-    }
-
-    /** @inheriteddoc */
-    componentWillMount() {
-        applicationStore.addActionsChangeListener(this._handleComponentChange);
-    }
-
-    /** @inheriteddoc */
-    componentWillUnmount() {
-        applicationStore.removeActionsChangeListener(this._handleComponentChange);
-    }
-
-    /**
-    * Get state from store
-    * @return {Object} actions extracted from the store
-    */
-    _getStateFromStore() {
-        return {
-            actions: applicationStore.getActions() || { primary: [], secondary: [] }
-        };
-    }
-
-    /**
-    * Component change handler
-    */
-    _handleComponentChange() {
-        this.setState(this._getStateFromStore());
-    }
 
     /**
      * Render a list fab component.
@@ -97,12 +63,11 @@ class HeaderActions extends Component {
 
     /** @inheritdoc */
     render() {
-        const props = this.props;
-        const { actions: { primary, secondary } } = this.state;
+        const { actions: { primary, secondary }, others } = this.props;
 
         return (
-            <div data-focus='header-actions' {...props}>
-                {primary.map((action) => this.renderFabAction(action))}
+            <div data-focus='header-actions' {...others}>
+                {primary.map((action) => action && Array.isArray(action.action) ? this.renderFabListAction(action) : this.renderFabAction(action))}
                 {Array.isArray(secondary) && this.renderFabListAction({ action: secondary })}
                 {isObject(secondary) && this.renderFabListAction(secondary)}
             </div>

--- a/src/components/layout/header-actions.js
+++ b/src/components/layout/header-actions.js
@@ -1,5 +1,9 @@
+// Libs
 import React, { Component } from 'react';
+import isObject from 'lodash/lang/isObject';
+// Stores
 import applicationStore from 'focus-core/application/built-in-store';
+// Components
 import Button from '../../components/button';
 import Dropdown from '../../components/icon-dropdown';
 
@@ -8,9 +12,19 @@ import Dropdown from '../../components/icon-dropdown';
 */
 class HeaderActions extends Component {
 
+    /** Display name. */
+    static displayName = 'HeaderActions';
+
+    /**
+     * Constructor.
+     * @param {object} props Props.
+     */
     constructor(props) {
         super(props);
+
         this.state = this._getStateFromStore();
+
+        this._handleComponentChange = this._handleComponentChange.bind(this);
     }
 
     /** @inheriteddoc */
@@ -27,46 +41,73 @@ class HeaderActions extends Component {
     * Get state from store
     * @return {Object} actions extracted from the store
     */
-    _getStateFromStore = () => {
-        return { actions: applicationStore.getActions() || { primary: [], secondary: [] } };
-    };
+    _getStateFromStore() {
+        return {
+            actions: applicationStore.getActions() || { primary: [], secondary: [] }
+        };
+    }
 
     /**
     * Component change handler
     */
-    _handleComponentChange = () => {
+    _handleComponentChange() {
         this.setState(this._getStateFromStore());
-    };
+    }
 
-    /** @inheriteddoc */
+    /**
+     * Render a list fab component.
+     * @param {object} fab Fab.
+     * @returns {JSXElement} Component.
+     */
+    renderFabListAction(fab) {
+        if (Array.isArray(fab.action) && fab.action.length > 0) {
+            const { icon, iconLibrary, action, ...otherProps } = fab;
+            return (
+                <Dropdown
+                    iconProps={{ name: icon, iconLibrary }}
+                    operationList={action}
+                    shape='fab'
+                    {...otherProps}
+                />
+            );
+        }
+    }
+
+    /**
+     * Render a fab component.
+     * @param {object} fab Fab.
+     * @returns {JSXElement} Component.
+     */
+    renderFabAction(fab) {
+        const { action, className, icon, iconLibrary, label, ...otherProps } = fab;
+        return (
+            <Button
+                key={`header-action-${label}`}
+                className={className}
+                handleOnClick={action}
+                icon={icon}
+                iconLibrary={iconLibrary}
+                label={label}
+                shape='fab'
+                type='button'
+                {...otherProps}
+            />
+        );
+    }
+
+    /** @inheritdoc */
     render() {
-        const { ...otherProps } = this.props;
-        const { actions } = this.state;
+        const props = this.props;
+        const { actions: { primary, secondary } } = this.state;
 
         return (
-            <div data-focus='header-actions' {...otherProps}>
-                {actions.primary.map((primary) => {
-                    const { action, className, icon, iconLibrary, label, ...otherProps } = primary;
-                    return (
-                        <Button
-                            key={`header-action-${label}`}
-                            className={className}
-                            handleOnClick={action}
-                            icon={icon}
-                            iconLibrary={iconLibrary}
-                            label={label}
-                            shape='fab'
-                            type='button'
-                            {...otherProps}
-                        />
-                    );
-                })}
-                {actions.secondary && actions.secondary.length > 0 && (<Dropdown operationList={actions.secondary} />)}
+            <div data-focus='header-actions' {...props}>
+                {primary.map((action) => this.renderFabAction(action))}
+                {Array.isArray(secondary) && this.renderFabListAction({ action: secondary })}
+                {isObject(secondary) && this.renderFabListAction(secondary)}
             </div>
         );
     }
 }
-
-HeaderActions.displayName = 'HeaderActions';
 
 export default HeaderActions;

--- a/src/components/layout/header-actions.js
+++ b/src/components/layout/header-actions.js
@@ -1,7 +1,7 @@
 // Libs
-import React, { Component } from 'react';
+import React, { PropTypes } from 'react';
 import isObject from 'lodash/lang/isObject';
-
+import filterProps from '../../utils/filter-html-attributes';
 // Stores
 import applicationStore from 'focus-core/application/built-in-store';
 // Components
@@ -9,70 +9,104 @@ import Button from '../../components/button';
 import Dropdown from '../../components/icon-dropdown';
 import storeConnect from '../../behaviours/store/connect';
 
-/**
-* HeaderActions component.
-*/
-@storeConnect([
-    { store: applicationStore, properties: ['actions'] }
-], () => ({ actions: applicationStore.getActions() || { primary: [], secondary: [] } }))
-class HeaderActions extends Component {
+/** Connector for HeaderActions. */
+const connector = storeConnect([{
+    store: applicationStore,
+    properties: ['actions']
+}], () => ({
+    actions: applicationStore.getActions() || { primary: [], secondary: [] }
+}));
 
-    /** Display name. */
-    static displayName = 'HeaderActions';
+/** Sub-action type. */
+const subActionType = PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    action: PropTypes.func.isRequired
+}));
 
-    /**
-     * Render a list fab component.
-     * @param {object} fab Fab.
-     * @returns {JSXElement} Component.
-     */
-    renderFabListAction(fab) {
-        if (Array.isArray(fab.action) && fab.action.length > 0) {
-            const { icon, iconLibrary, action, ...otherProps } = fab;
-            return (
-                <Dropdown
-                    iconProps={{ name: icon, iconLibrary }}
-                    operationList={action}
-                    shape='fab'
-                    {...otherProps}
-                />
-            );
-        }
+/** Action type. */
+const actionType = PropTypes.oneOfType([
+    { // Icon action
+        label: PropTypes.string.isRequired,
+        action: PropTypes.func.isRequired,
+        icon: PropTypes.string.isRequired,
+        iconLibrary: PropTypes.string,
+        className: PropTypes.string
+    },
+    { // Dropdown action
+        icon: PropTypes.string,
+        iconLibrary: PropTypes.string,
+        action: subActionType.isRequired
     }
+]);
 
-    /**
-     * Render a fab component.
-     * @param {object} fab Fab.
-     * @returns {JSXElement} Component.
-     */
-    renderFabAction(fab) {
-        const { action, className, icon, iconLibrary, label, ...otherProps } = fab;
+/** Proptypes validation for HeaderActions. */
+const propTypes = {
+    actions: PropTypes.shape({
+        primary: PropTypes.arrayOf(actionType),
+        secondary: PropTypes.oneOfType([
+            subActionType,
+            actionType
+        ])
+    }).isRequired
+};
+
+/**
+ * Render a list fab component.
+ * @param {object} fab Fab.
+ * @returns {JSXElement} Component.
+ */
+function renderFabListAction(fab) {
+    if (Array.isArray(fab.action) && fab.action.length > 0) {
+        const { icon, iconLibrary, action, ...otherProps } = fab;
         return (
-            <Button
-                key={`header-action-${label}`}
-                className={className}
-                handleOnClick={action}
-                icon={icon}
-                iconLibrary={iconLibrary}
-                label={label}
+            <Dropdown
+                iconProps={{ name: icon, iconLibrary }}
+                operationList={action}
                 shape='fab'
-                type='button'
                 {...otherProps}
             />
         );
     }
-
-    /** @inheritdoc */
-    render() {
-        const { actions: { primary, secondary }, others } = this.props;
-
-        return (
-            <div data-focus='header-actions' {...others}>
-                {primary.map((action) => action && Array.isArray(action.action) ? this.renderFabListAction(action) : this.renderFabAction(action))}
-                {Array.isArray(secondary) && this.renderFabListAction({ action: secondary })}
-                {isObject(secondary) && this.renderFabListAction(secondary)}
-            </div>
-        );
-    }
 }
 
-export default HeaderActions;
+/**
+ * Render a fab component.
+ * @param {object} fab Fab.
+ * @returns {JSXElement} Component.
+ */
+function renderFabAction(fab) {
+    const { action, className, icon, iconLibrary, label, ...otherProps } = fab;
+    return (
+        <Button
+            key={`header-action-${label}`}
+            className={className}
+            handleOnClick={action}
+            icon={icon}
+            iconLibrary={iconLibrary}
+            label={label}
+            shape='fab'
+            type='button'
+            {...otherProps}
+        />
+    );
+}
+
+/**
+ * HeaderActions component.
+ * @returns {JSXElement} Component.
+ */
+const HeaderActions = ({ actions: { primary, secondary }, ...otherProps }) => {
+    return (
+        <div data-focus='header-actions' {...filterProps(otherProps)}>
+            {primary.map((action) => {
+                return action && Array.isArray(action.action) ? renderFabListAction(action) : renderFabAction(action)
+            })}
+            {Array.isArray(secondary) && renderFabListAction({ action: secondary })}
+            {isObject(secondary) && renderFabListAction(secondary)}
+        </div>
+    );
+};
+HeaderActions.displayName = 'HeaderActions';
+HeaderActions.propTypes = propTypes;
+
+export default connector(HeaderActions);

--- a/src/components/layout/header-content.js
+++ b/src/components/layout/header-content.js
@@ -6,9 +6,19 @@ import applicationStore from 'focus-core/application/built-in-store';
 */
 class HeaderContent extends Component {
 
+    /** Display name. */
+    static displayName = 'HeaderContent';
+
+    /**
+     * Constructor.
+     * @param {object} props Props.
+     */
     constructor(props) {
         super(props);
+
         this.state = this._getStateFromStore();
+
+        this._handleComponentChange = this._handleComponentChange.bind(this);
     }
 
     /** @inheriteddoc */
@@ -25,21 +35,23 @@ class HeaderContent extends Component {
     * Read the component state from the connected stores.
     * @return {object} - The new state.
     */
-    _getStateFromStore = () => {
-        return { cartridgeComponent: applicationStore.getCartridgeComponent() || { component: 'div', props: {} } };
-    };
+    _getStateFromStore() {
+        return {
+            cartridgeComponent: applicationStore.getCartridgeComponent() || { component: 'div', props: {} }
+        };
+    }
 
     /**
     * Handle the component change cb.
     */
-    _handleComponentChange = () => {
+    _handleComponentChange() {
         this.setState(this._getStateFromStore());
-    };
+    }
 
-    /** @inheriteddoc */
+    /** @inheritdoc */
     render() {
-        const { cartridgeComponent } = this.state;
-        const { component: Component, props } = cartridgeComponent;
+        const { cartridgeComponent: { component: Component, props } } = this.state;
+
         return (
             <div data-focus='header-content'>
                 <Component {...props} />
@@ -47,7 +59,5 @@ class HeaderContent extends Component {
         );
     }
 }
-
-HeaderContent.displayName = 'HeaderContent';
 
 export default HeaderContent;

--- a/src/components/layout/style/header-actions.scss
+++ b/src/components/layout/style/header-actions.scss
@@ -1,6 +1,8 @@
 
 [data-focus="header-actions"] {
     text-align: right;
+    display: flex;
+    
     button {
         margin: 0 5px;
         &.mdl-button--fab {
@@ -9,8 +11,5 @@
         &:hover {
             background-color: #F9F9F9 !important;
         }
-    }
-    div {
-        float: right;
     }
 }

--- a/src/components/layout/style/header-scrolling.scss
+++ b/src/components/layout/style/header-scrolling.scss
@@ -41,10 +41,6 @@ to { height: auto; }
         background-color: rgba(255, 255, 255, 1);
     }
 
-    [data-focus="header-actions"] {
-        display: inline;
-    }
-
     // When the header is deployed, don't show the summary.
     &[data-deployed="true"] {
         div[data-focus="header-top-row"] {


### PR DESCRIPTION
Fix: #1467

### Description

* **primary**: now accepts an `iconLibrary` option to change icon library.
* **secondary**: can now be an object with keys similar to **primary**: `icon`, `iconLibrary`, `action`. 

```js
{
    primary: [
        { icon, iconLibrary, label, className, action },
        // or
        { icon, iconLibrary, action: [
            { label, action, style },
            [...]
        ]},
        [...]
    ],
    secondary: [
        { label, action, style },
        [...]
    ],
    // or
    secondary: { icon, iconLibrary, action: [
        { label, action, style },
        [...]
    ]}
}
```
note: `style` prop in action array is only available in legacy component.