### PR TITLE
Reference-behaviour : avoid reloading reference list if not needed

### DIFF
--- a/src/common/form/mixin/reference-behaviour.js
+++ b/src/common/form/mixin/reference-behaviour.js
@@ -53,8 +53,11 @@ const referenceMixin = {
 
     componentWillReceiveProps({ referenceNames }) {
         if (referenceNames) {
+            const shouldReload = difference(referenceNames, this.referenceNames).length > 0;
             this._buildReference(referenceNames, this.referenceNames);
-            this._loadReference();
+            if(shouldReload) {
+                this._loadReference();
+            }
         }
     },
 


### PR DESCRIPTION
In some case, it causes infinite re-render