### PR TITLE
_handleAutocompleteChange as props to Edit component

### DIFF
--- a/src/components/input/autocomplete-text/field.js
+++ b/src/components/input/autocomplete-text/field.js
@@ -21,13 +21,6 @@ class AutocompleteTextField extends Component {
         }
     };
 
-    _handleAutocompleteChange = value => {
-        const { onChange } = this.props;
-        if (onChange) {
-            onChange(value);
-        }
-    };
-
     _renderEdit = () => {
         return (
             <AutocompleteTextEdit


### PR DESCRIPTION
## Autocomplete-text Component

### Description

The _handleAutocompleteChange method is not given as a props to the Edit component. 

I didn't see any use of the onChange props in the Edit component ( it is overloaded by onQueryChange, which also does not use onChange props ), so i think the method can be removed.
