### PR TITLE
Form should call _customValidation even if fields aren't valid

### DIFF
--- a/src/common/form/mixin/validation-behaviour.js
+++ b/src/common/form/mixin/validation-behaviour.js
@@ -36,7 +36,10 @@ function _customValidation() {
  * @return {boolean} - True if the validation is ok.
  */
 function _validate() {
-    return this._fieldsValidation() && this._customValidation();
+    const fieldsValidation = this._fieldsValidation();
+    const customValidation = this._customValidation();
+    
+    return fieldsValidation && customValidation;
 }
 
 export default {


### PR DESCRIPTION
## [FormMixin] 

Both validations should be called at all time.