### PR TITLE
Form error clean-up

### DIFF
--- a/src/common/mixin/built-in-components.js
+++ b/src/common/mixin/built-in-components.js
@@ -156,7 +156,6 @@ export default {
         const handleOnClick = () => {
             this.setState({ isEdit: !this.state.isEdit }, () => {
                 changeMode('edit', 'consult');
-                this.clearError();
             });
         };
         return (
@@ -193,6 +192,7 @@ export default {
     buttonSave() {
         const { isLoading } = this.state;
         const handleOnClick = () => {
+            this.clearError();
             if (this._validate()) {
                 this.action.save.call(this, this._getEntity());
             }


### PR DESCRIPTION
[build-in-components]

Errors should be cleared & recalculated right before the save. This way, if the form has multiple errors, the user can correct the first error, click save & only the remaining errors will be shown.

Right now, errors are not cleared on Save. So the components still have an error props, even though they are no errors.