### PR TITLE
Fix of uncontrolled input

### DIFF
--- a/src/components/input/radio/index.js
+++ b/src/components/input/radio/index.js
@@ -77,7 +77,7 @@ class Radio extends Component {
         const validInputProps = filterProps(this.props);
 
         validInputProps.onChange = this._onChange;
-        validInputProps.checked = isChecked ? 'checked' : undefined;
+        validInputProps.checked = isChecked ? 'checked' : '';
         const inputProps = { ...validInputProps };
 
         return (


### PR DESCRIPTION
When ```undefined``` is passed as the ```checked``` props of the input, this one is considered as uncontrolled, and an uncontrolled component sometimes cannot change its value via React, resulting in an input which changes cannot be controlled by focus. Passing ```''``` instead of ```undefined``` fix this error.